### PR TITLE
Create identity_shared_attributes for things that span recipes/repos

### DIFF
--- a/identity_shared_attributes/.gitignore
+++ b/identity_shared_attributes/.gitignore
@@ -1,0 +1,22 @@
+.vagrant
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+gems.locked
+bin/*
+.bundle/*
+
+# test kitchen
+.kitchen/
+.kitchen.local.yml
+
+# Chef
+Berksfile.lock
+.zero-knife.rb
+Policyfile.lock.json

--- a/identity_shared_attributes/README.md
+++ b/identity_shared_attributes/README.md
@@ -1,0 +1,9 @@
+# identity_shared_attributes
+
+The identity_shared_attributes cookbook stores values used by multiple recipes
+in multiple repositories.
+
+# Usage
+
+Including the default recipe from anywhere should define the relevant node
+attributes.

--- a/identity_shared_attributes/attributes/default.rb
+++ b/identity_shared_attributes/attributes/default.rb
@@ -1,0 +1,3 @@
+default[:identity_shared_attributes][:cache_dir] = '/var/cache/chef'
+default[:identity_shared_attributes][:openssl_version] = '1.0.2o'
+default[:identity_shared_attributes][:production_user] = 'websrv'

--- a/identity_shared_attributes/chefignore
+++ b/identity_shared_attributes/chefignore
@@ -1,0 +1,107 @@
+# Put files/directories that should be ignored in this file when uploading
+# to a chef-server or supermarket.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+examples/*
+Guardfile
+Procfile
+.kitchen*
+.rubocop.yml
+spec/*
+Rakefile
+.travis.yml
+.foodcritic
+.codeclimate.yml
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Policyfile #
+##############
+Policyfile.rb
+Policyfile.lock.json
+
+# Cookbooks #
+#############
+CONTRIBUTING*
+CHANGELOG*
+TESTING*
+MAINTAINERS.toml
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile

--- a/identity_shared_attributes/metadata.rb
+++ b/identity_shared_attributes/metadata.rb
@@ -2,7 +2,7 @@ name 'identity_shared_attributes'
 maintainer 'The Login.gov Team'
 maintainer_email 'identity-devops@login.gov'
 license 'CC0-1.0'
-description 'NTP setup for login.gov'
+description 'shared attributes for login.gov'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 chef_version '>= 13.0' if respond_to?(:chef_version)

--- a/identity_shared_attributes/metadata.rb
+++ b/identity_shared_attributes/metadata.rb
@@ -1,0 +1,11 @@
+name 'identity_shared_attributes'
+maintainer 'The Login.gov Team'
+maintainer_email 'identity-devops@login.gov'
+license 'CC0-1.0'
+description 'NTP setup for login.gov'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'
+chef_version '>= 13.0' if respond_to?(:chef_version)
+
+issues_url 'https://github.com/18F/identity-cookbooks/issues'
+source_url 'https://github.com/18F/identity-cookbooks'


### PR DESCRIPTION
I tested this by running the IDP and PIV/CAC Kitchen tests from [this branch](https://github.com/18F/identity-devops/compare/mark-from-usds/identity_shared_attributes01?expand=1).