### PR TITLE
Increase connection rate limit to 20 request per 5 minutes

### DIFF
--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -38,7 +38,7 @@ http {
   large_client_header_buffers 2 20k;
 <% if @passenger.fetch(:limit_connections) %>
   # Limit connections
-  limit_conn addr       10;
+  limit_conn addr       20;
   limit_conn_status     429;
   limit_conn_zone       $binary_remote_addr zone=addr:5m;
 <% end -%>


### PR DESCRIPTION
Currently we're receiving many alerts in #identity-events for exceeding this limit but we are not observing any DoS or degradation with login.gov.  Will increase the connection rate limit to a higher setting.