### PR TITLE
Move login_dot_gov::ruby into identity_base_config

### DIFF
--- a/identity_base_config/metadata.rb
+++ b/identity_base_config/metadata.rb
@@ -9,3 +9,5 @@ chef_version '>= 13.0' if respond_to?(:chef_version)
 
 issues_url 'https://github.com/18F/identity-cookbooks/issues'
 source_url 'https://github.com/18F/identity-cookbooks'
+
+depends 'identity_shared_attributes'

--- a/identity_base_config/recipes/ruby.rb
+++ b/identity_base_config/recipes/ruby.rb
@@ -20,7 +20,7 @@ global_env_vars = {
 }
 
 # Set proxy environment variables if present in Chef config
-['http_proxy', 'https_proxy', 'no_proxy'].each |proxy_variable| do
+['http_proxy', 'https_proxy', 'no_proxy'].each do |proxy_variable|
   if Chef::Config.fetch(proxy_variable)
     global_env_vars[proxy_variable] = Chef::Config.fetch(proxy_variable)
   end

--- a/identity_base_config/recipes/ruby.rb
+++ b/identity_base_config/recipes/ruby.rb
@@ -28,8 +28,8 @@ end
 
 # New Relic wants its proxy hostname and port separated. Our provision script
 # leaves those in files in /etc/login.gov/info.
-global_env_vars['NEW_RELIC_PROXY_HOST'] = read_env_file('/etc/login.gov/info/proxy_server')
-global_env_vars['NEW_RELIC_PROXY_PORT'] = read_env_file('/etc/login.gov/info/proxy_server')
+global_env_vars['NEW_RELIC_PROXY_HOST'] = node.fetch('identity_shared_attributes').fetch('proxy_server')
+global_env_vars['NEW_RELIC_PROXY_PORT'] = node.fetch('identity_shared_attributes').fetch('proxy_port')
 
 # hack to set all the env variables from /etc/environment such as PATH and
 # RAILS_ENV for all subprocesses during this chef run

--- a/identity_base_config/recipes/ruby.rb
+++ b/identity_base_config/recipes/ruby.rb
@@ -22,7 +22,6 @@ global_env_vars = {
 # Set proxy environment variables if present in Chef config
 ['http_proxy', 'https_proxy', 'no_proxy'].each do |proxy_variable|
   if Chef::Config.fetch(proxy_variable)
-    Chef::Log.warn("Setting #{proxy_variable} to #{Chef::Config[proxy_variable]}")
     global_env_vars[proxy_variable] = Chef::Config[proxy_variable]
   end
 end

--- a/identity_base_config/recipes/ruby.rb
+++ b/identity_base_config/recipes/ruby.rb
@@ -1,0 +1,59 @@
+# Ruby environment / installation
+rbenv_root = node.fetch('identity_shared_attributes').fetch('rbenv_root')
+
+# sanity checks that identity-ruby correctly installed ruby in the base AMI
+unless File.exist?(rbenv_root)
+  raise "Cannot find rbenv_root at #{rbenv_root.inspect} -- was it created in the base AMI?"
+end
+unless File.exist?(rbenv_root + '/shims/ruby')
+  raise "Cannot find ruby shim in rbenv_root under #{rbenv_root.inspect} -- was it created in the base AMI?"
+end
+unless File.exist?(rbenv_root + '/shims/gem')
+  raise "Cannot find gem shim in rbenv_root under #{rbenv_root.inspect} -- was it created in the base AMI?"
+end
+
+global_env_vars = {
+  'RBENV_ROOT' => rbenv_root,
+  'PATH' => "/opt/chef/bin:#{rbenv_root}/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games",
+  'RAILS_ENV' => 'production',
+  'RACK_ENV' => 'production',
+}
+
+# Set proxy environment variables if present in Chef config
+['http_proxy', 'https_proxy', 'no_proxy'].each |proxy_variable| do
+  if Chef::Config.fetch(proxy_variable)
+    global_env_vars[proxy_variable] = Chef::Config.fetch(proxy_variable)
+  end
+end
+
+# New Relic wants its proxy hostname and port separated. Our provision script
+# leaves those in files in /etc/login.gov/info.
+global_env_vars['NEW_RELIC_PROXY_HOST'] = read_env_file('/etc/login.gov/info/proxy_server')
+global_env_vars['NEW_RELIC_PROXY_PORT'] = read_env_file('/etc/login.gov/info/proxy_server')
+
+# hack to set all the env variables from /etc/environment such as PATH and
+# RAILS_ENV for all subprocesses during this chef run
+global_env_vars.each_pair do |key, val|
+  ENV[key] = val
+end
+
+file '/etc/environment' do
+  header = <<-EOM
+    # Dropped off by chef
+    # This is a static file (not script) used by PAM to set env variables.
+  EOM
+  content(
+    header + global_env_vars.map { |key, val| "#{key}='#{val}'" }.join("\n") \
+    + "\n"
+  )
+  notifies :run, 'execute[restart_snapd]'
+end
+
+execute 'restart_snapd' do
+  command 'systemctl restart snapd'
+  action :nothing
+end
+
+# install dependencies
+package 'libpq-dev'
+package 'libsasl2-dev'

--- a/identity_base_config/recipes/ruby.rb
+++ b/identity_base_config/recipes/ruby.rb
@@ -22,8 +22,8 @@ global_env_vars = {
 # Set proxy environment variables if present in Chef config
 ['http_proxy', 'https_proxy', 'no_proxy'].each do |proxy_variable|
   if Chef::Config.fetch(proxy_variable)
-    Chef::Log.warn("Setting #{proxy_variable} to #{Chef::Config.fetch(proxy_variable)}")
-    global_env_vars[proxy_variable] = Chef::Config.fetch(proxy_variable)
+    Chef::Log.warn("Setting #{proxy_variable} to #{Chef::Config[proxy_variable]}")
+    global_env_vars[proxy_variable] = Chef::Config[proxy_variable]
   end
 end
 

--- a/identity_base_config/recipes/ruby.rb
+++ b/identity_base_config/recipes/ruby.rb
@@ -22,6 +22,7 @@ global_env_vars = {
 # Set proxy environment variables if present in Chef config
 ['http_proxy', 'https_proxy', 'no_proxy'].each do |proxy_variable|
   if Chef::Config.fetch(proxy_variable)
+    Chef::Log.info("Setting #{proxy_variable} to #{Chef::Config.fetch(proxy_variable)}")
     global_env_vars[proxy_variable] = Chef::Config.fetch(proxy_variable)
   end
 end

--- a/identity_base_config/recipes/ruby.rb
+++ b/identity_base_config/recipes/ruby.rb
@@ -22,7 +22,7 @@ global_env_vars = {
 # Set proxy environment variables if present in Chef config
 ['http_proxy', 'https_proxy', 'no_proxy'].each do |proxy_variable|
   if Chef::Config.fetch(proxy_variable)
-    Chef::Log.info("Setting #{proxy_variable} to #{Chef::Config.fetch(proxy_variable)}")
+    Chef::Log.warn("Setting #{proxy_variable} to #{Chef::Config.fetch(proxy_variable)}")
     global_env_vars[proxy_variable] = Chef::Config.fetch(proxy_variable)
   end
 end

--- a/identity_base_config/recipes/ruby.rb
+++ b/identity_base_config/recipes/ruby.rb
@@ -1,5 +1,6 @@
 # Ruby environment / installation
-rbenv_root = node.fetch('identity_shared_attributes').fetch('rbenv_root')
+
+rbenv_root = node.fetch('identity-ruby').fetch('rbenv_root')
 
 # sanity checks that identity-ruby correctly installed ruby in the base AMI
 unless File.exist?(rbenv_root)
@@ -19,17 +20,14 @@ global_env_vars = {
   'RACK_ENV' => 'production',
 }
 
-# Set proxy environment variables if present in Chef config
-['http_proxy', 'https_proxy', 'no_proxy'].each do |proxy_variable|
-  if Chef::Config.fetch(proxy_variable)
-    global_env_vars[proxy_variable] = Chef::Config[proxy_variable]
-  end
+# Set proxy environment variables if present in attributes
+if node.fetch('login_dot_gov').fetch('proxy_server')
+  global_env_vars['http_proxy']           = node.fetch('login_dot_gov').fetch('http_proxy')
+  global_env_vars['https_proxy']          = node.fetch('login_dot_gov').fetch('https_proxy')
+  global_env_vars['no_proxy']             = node.fetch('login_dot_gov').fetch('no_proxy')
+  global_env_vars['NEW_RELIC_PROXY_HOST'] = node.fetch('login_dot_gov').fetch('proxy_server')
+  global_env_vars['NEW_RELIC_PROXY_PORT'] = node.fetch('login_dot_gov').fetch('proxy_port')
 end
-
-# New Relic wants its proxy hostname and port separated. Our provision script
-# leaves those in files in /etc/login.gov/info.
-global_env_vars['NEW_RELIC_PROXY_HOST'] = node.fetch('identity_shared_attributes').fetch('proxy_server')
-global_env_vars['NEW_RELIC_PROXY_PORT'] = node.fetch('identity_shared_attributes').fetch('proxy_port')
 
 # hack to set all the env variables from /etc/environment such as PATH and
 # RAILS_ENV for all subprocesses during this chef run

--- a/identity_shared_attributes/attributes/default.rb
+++ b/identity_shared_attributes/attributes/default.rb
@@ -12,5 +12,6 @@ default[:identity_shared_attributes][:cache_dir] = '/var/cache/chef'
 default[:identity_shared_attributes][:openssl_version] = '1.0.2o'
 default[:identity_shared_attributes][:production_user] = 'websrv'
 default[:identity_shared_attributes][:system_user] = 'appinstall'
+default[:identity_shared_attributes][:proxy_server] = read_env_file('/etc/login.gov/info/proxy_server')
 default[:identity_shared_attributes][:proxy_port] = read_env_file('/etc/login.gov/info/proxy_port')
 default[:identity_shared_attributes][:rbenv_root] = '/opt/ruby_build'

--- a/identity_shared_attributes/attributes/default.rb
+++ b/identity_shared_attributes/attributes/default.rb
@@ -1,4 +1,16 @@
+def read_env_file(filename)
+  return nil unless ::File.exist?(filename)
+  data = ::File.read(filename).chomp
+  if data.empty?
+    nil
+  else
+    data
+  end
+end
+
 default[:identity_shared_attributes][:cache_dir] = '/var/cache/chef'
 default[:identity_shared_attributes][:openssl_version] = '1.0.2o'
 default[:identity_shared_attributes][:production_user] = 'websrv'
 default[:identity_shared_attributes][:system_user] = 'appinstall'
+default[:identity_shared_attributes][:proxy_port] = read_env_file('/etc/login.gov/info/proxy_port')
+default[:identity_shared_attributes][:rbenv_root] = '/opt/ruby_build'

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -91,7 +91,7 @@ template "#{nginx_path}/conf/nginx.conf" do
       # dynamically compute passenger root at converge using rbenv
       shell_out!(%w{rbenv exec passenger-config --root}).stdout
     },
-    ruby_path: node.fetch('identity-ruby').fetch('rbenv_root') + '/shims/ruby',
+    ruby_path: node.fetch(:identity_shared_attributes).fetch(:rbenv_root) + '/shims/ruby',
     :passenger => node[:passenger][:production],
     :pidfile => "/var/run/nginx.pid",
     :passenger_user => node[:passenger][:production][:user]

--- a/passenger/recipes/install.rb
+++ b/passenger/recipes/install.rb
@@ -3,7 +3,7 @@
 # Recipe:: install
 
 gem_package "passenger/system" do
-  gem_binary (node.fetch('identity-ruby').fetch('rbenv_root') + '/shims/gem')
+  gem_binary (node.fetch(:identity_shared_attributes).fetch(:rbenv_root) + '/shims/gem')
   package_name 'passenger'
   version node[:passenger][:production][:version]
   notifies :run, 'execute[rbenv rehash]', :immediately


### PR DESCRIPTION
Add proxy_server (i.e. the proxy without the https:// or the port), proxy_port, and rbenv_root to identity_shared attributes and use them when possible.

Since this is across repos, you can see the exact changes I made to the version in identity-devops in [this commit](https://github.com/18F/identity-cookbooks/commit/3761691bcb7b31bea03c7d79b099f997bb81d1a1).