### PR TITLE
Passenger config fixes and optimizations

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -13,7 +13,7 @@ default[:passenger][:production][:log_path] = '/var/log/nginx'
 default[:passenger][:production][:status_server] = true
 
 default[:passenger][:production][:user] = node.fetch(:identity_shared_attributes).fetch(:production_user)
-default[:passenger][:production][:version] = '5.3.3'
+default[:passenger][:production][:version] = '5.3.7'
 
 # Allow our local /16 to proxy setting X-Forwarded-For
 # This is a little broad, but because we expect security group rules to prevent

--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -38,7 +38,7 @@ default[:passenger][:production][:max_instances_per_app] = 0
 default[:passenger][:production][:pool_idle_time] = 0
 
 # a list of URL's to pre-start.
-default[:passenger][:production][:pre_start] = []
+default[:passenger][:production][:pre_start] = ['https://localhost']
 
 default[:passenger][:production][:sendfile] = true
 default[:passenger][:production][:tcp_nopush] = false

--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -9,9 +9,10 @@ default[:passenger][:production][:log_path] = '/var/log/nginx'
 default[:passenger][:production][:native_support_dir] = node.fetch(:passenger).fetch(:production).fetch(:path) + '/passenger-native-support'
 
 # Tune these for your environment, see:
-# http://www.modrails.com/documentation/Users%20guide%20Nginx.html#_resource_control_and_optimization_options
+# https://www.phusionpassenger.com/library/config/nginx/optimization
+# Keep max_pool_size and min_instances the same to create a fixed process pool
 default[:passenger][:production][:max_pool_size] = node.fetch('cpu').fetch('total') * 2
-default[:passenger][:production][:min_instances] = node.fetch('cpu').fetch('total')
+default[:passenger][:production][:min_instances] = node.fetch('cpu').fetch('total') * 2
 default[:passenger][:production][:pool_idle_time] = 0
 default[:passenger][:production][:max_instances_per_app] = 0
 default[:passenger][:production][:limit_connections] = true

--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -1,40 +1,45 @@
-default[:passenger][:production][:path] = '/opt/nginx'
-
 cache_dir = node.fetch(:identity_shared_attributes).fetch(:cache_dir)
+
 openssl_version = node.fetch(:identity_shared_attributes).fetch(:openssl_version)
 openssl_srcpath = "#{cache_dir}/openssl-#{openssl_version}"
-default[:passenger][:production][:configure_flags] = "--with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-openssl=#{openssl_srcpath}"
-default[:passenger][:production][:log_path] = '/var/log/nginx'
 
+default[:passenger][:production][:path] = '/opt/nginx'
 default[:passenger][:production][:native_support_dir] = node.fetch(:passenger).fetch(:production).fetch(:path) + '/passenger-native-support'
 
-# Tune these for your environment, see:
-# https://www.phusionpassenger.com/library/config/nginx/optimization
-# Keep max_pool_size and min_instances the same to create a fixed process pool
-default[:passenger][:production][:max_pool_size] = node.fetch('cpu').fetch('total') * 2
-default[:passenger][:production][:min_instances] = node.fetch('cpu').fetch('total') * 2
-default[:passenger][:production][:pool_idle_time] = 0
-default[:passenger][:production][:max_instances_per_app] = 0
-default[:passenger][:production][:limit_connections] = true
-
-# a list of URL's to pre-start.
-default[:passenger][:production][:pre_start] = []
-default[:passenger][:production][:sendfile] = true
-default[:passenger][:production][:tcp_nopush] = false
-
-# Nginx's default is 0, but we don't want that.
-default[:passenger][:production][:keepalive_timeout] = '60 50'
-default[:passenger][:production][:gzip] = true
-default[:passenger][:production][:worker_connections] = 1024
+default[:passenger][:production][:configure_flags] = "--with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-openssl=#{openssl_srcpath}"
+default[:passenger][:production][:log_path] = '/var/log/nginx'
 
 # Enable the status server on 127.0.0.1
 default[:passenger][:production][:status_server] = true
 
-default[:passenger][:production][:version] = '5.3.3'
 default[:passenger][:production][:user] = node.fetch(:identity_shared_attributes).fetch(:production_user)
+default[:passenger][:production][:version] = '5.3.3'
 
 # Allow our local /16 to proxy setting X-Forwarded-For
 # This is a little broad, but because we expect security group rules to prevent
 # anyone except our trusted ALB from connecting anyway, we don't really care
 # who is able to set X-Forwarded-For headers.
 default[:passenger][:production][:realip_from_cidr] = node.fetch(:cloud).fetch('local_ipv4').split('.')[0..1].join('.') + '.0.0/16'
+
+# Tune the following configurations for your environment. For more info see:
+# https://www.phusionpassenger.com/library/config/nginx/optimization
+default[:passenger][:production][:gzip] = true
+
+# Nginx's default is 0, but we don't want that.
+default[:passenger][:production][:keepalive_timeout] = '60 50'
+
+default[:passenger][:production][:limit_connections] = true
+
+# Keep max_pool_size and min_instances the same to create a fixed process pool
+default[:passenger][:production][:max_pool_size] = node.fetch('cpu').fetch('total') * 2
+default[:passenger][:production][:min_instances] = node.fetch('cpu').fetch('total') * 2
+
+default[:passenger][:production][:max_instances_per_app] = 0
+default[:passenger][:production][:pool_idle_time] = 0
+
+# a list of URL's to pre-start.
+default[:passenger][:production][:pre_start] = []
+
+default[:passenger][:production][:sendfile] = true
+default[:passenger][:production][:tcp_nopush] = false
+default[:passenger][:production][:worker_connections] = 1024

--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -42,4 +42,9 @@ default[:passenger][:production][:pre_start] = []
 
 default[:passenger][:production][:sendfile] = true
 default[:passenger][:production][:tcp_nopush] = false
+
+# Set worker processes to number of CPU cores until benchmarking shows that we
+# should do otherwise. See:
+# http://nginx.org/en/docs/ngx_core_module.html#worker_processes
+default[:passenger][:production][:worker_processes] = node.fetch('cpu').fetch('total')
 default[:passenger][:production][:worker_connections] = 1024

--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -38,7 +38,7 @@ default[:passenger][:production][:max_instances_per_app] = 0
 default[:passenger][:production][:pool_idle_time] = 0
 
 # a list of URL's to pre-start.
-default[:passenger][:production][:pre_start] = ['https://localhost']
+default[:passenger][:production][:pre_start] = []
 
 default[:passenger][:production][:sendfile] = true
 default[:passenger][:production][:tcp_nopush] = false

--- a/passenger/metadata.json
+++ b/passenger/metadata.json
@@ -29,5 +29,5 @@
     "passenger::daemon": "Install passenger/nginx as a service.",
     "passenger::standalone": "Install passenger/nginx and start it as standalone."
   },
-  "version": "0.0.6"
+  "version": "0.0.7"
 }

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -89,7 +89,7 @@ template "#{nginx_path}/conf/nginx.conf" do
     :log_path => log_path,
     passenger_root: lazy {
       # dynamically compute passenger root at converge using rbenv
-      shell_out!(%w{rbenv exec passenger-config --root}).stdout
+      shell_out!(%w{rbenv exec passenger-config --root}).stdout.chomp
     },
     ruby_path: node.fetch(:identity_shared_attributes).fetch(:rbenv_root) + '/shims/ruby',
     :passenger => node[:passenger][:production],

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -14,7 +14,7 @@ nginx_path = node.fetch(:passenger).fetch(:production).fetch(:path)
 bash "install passenger/nginx" do
   code <<-EOH
   set -eux
-  rbenv exec passenger-install-nginx-module --auto --auto-download --prefix="#{nginx_path}" --extra-configure-flags="#{node[:passenger][:production][:configure_flags]}"
+  rbenv exec passenger-install-nginx-module --auto --auto-download --languages ruby --prefix="#{nginx_path}" --extra-configure-flags="#{node[:passenger][:production][:configure_flags]}"
   rbenv rehash
   EOH
   not_if "test -e #{nginx_path}/sbin/nginx"

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -17,6 +17,9 @@ http {
   passenger_ruby <%= @ruby_path %>;
   passenger_show_version_in_header off;
   passenger_user <%= @passenger_user %>;
+<% @passenger[:pre_start].each do |url| %>
+  passenger_pre_start <%= url %>;
+<% end %>
 
   include mime.types;
   default_type application/octet-stream;
@@ -101,7 +104,3 @@ http {
 
   include sites.d/*.conf;
 }
-
-<% @passenger[:pre_start].each do |url| %>
-  passenger_pre_start <%= url %>;
-<% end %>

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -92,7 +92,7 @@ http {
                   'http_x_forwarded_for="$http_x_forwarded_for" uri_query="$query_string" '
                   'uri_path="$uri" http_method="$request_method" '
                   'response_time="$upstream_response_time" cookie="$http_cookie" '
-                  'request_time="$request_time request="$request" '
+                  'request_time="$request_time" request="$request" '
                   'http_x_amzn_trace_id="http_x_amzn_trace_id"';
 
   access_log <%= @log_path or raise "no @log_path" %>/access.log kv;

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -1,5 +1,5 @@
 #user  nobody;
-worker_processes  5;
+worker_processes  <%= @passenger[:worker_processes] %>;
 pid <%= @pidfile %>;
 
 events {


### PR DESCRIPTION
__Why__
We do not want process scaling enabled on a host that only serves a single app. See: https://www.phusionpassenger.com/library/config/nginx/optimization/#minimizing-process-spawning

Fixes: 18F/identity-devops#1431

 In summary this PR:

- Disables dynamic scaling in Passenger and fixes the max process counts to 2x cpu count
- Further organizes default attributes used by the Passenger cookbook
- Adds a default config for nginx worker_processes directive and sets default to cpu count as recommended by http://nginx.org/en/docs/ngx_core_module.html#worker_processes
- Removes hardcoded value for worker_processes and adds variable to nginx conf template
- Configures Passenger Nginx module to only compile support for Ruby
- Fixes error with passenger_pre_start directive being located outside of nginx http config block.
- Removes new line chars from dynamically calculated passenger_root variable
- Fixes error in nginx kv log config that was missing a `"` for one of the kv pairs.
- Upgrades Passenger to latest 5.3.x release (5.3.7)