### PR TITLE
Add a helper script to skip the ASG abandon hook.

### DIFF
--- a/identity_base_config/files/default/id-asg-skip-abandon-hook
+++ b/identity_base_config/files/default/id-asg-skip-abandon-hook
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+# Prevent provision.sh from completing the ASG lifecycle hook with ABANDON when
+# bootstrapping / chef provisioning fails.
+
+if [ "$(id -u)" -ne 0 ]; then
+    set -x
+    exec sudo "$0" "$@"
+fi
+
+set -x
+touch /etc/login.gov/info/skip_abandon_hook

--- a/identity_base_config/metadata.rb
+++ b/identity_base_config/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'identity-devops@login.gov'
 license 'CC0-1.0'
 description 'Identity base config and packages'
 long_description 'Identity base config and packages'
-version '0.1.1'
+version '0.1.2'
 chef_version '>= 13.0' if respond_to?(:chef_version)
 
 issues_url 'https://github.com/18F/identity-cookbooks/issues'

--- a/identity_base_config/recipes/default.rb
+++ b/identity_base_config/recipes/default.rb
@@ -50,6 +50,13 @@ cookbook_file '/usr/local/bin/id-apt-upgrade' do
   mode '0755'
 end
 
+cookbook_file '/usr/local/bin/id-asg-skip-abandon-hook' do
+  source 'id-asg-skip-abandon-hook'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
 cookbook_file '/usr/local/bin/id-chef-client' do
   source 'id-chef-client'
   owner 'root'


### PR DESCRIPTION
When troubleshooting issues with instance provisioning, it is often
useful to keep an instance around for inspection. We have a flag file
that we can drop in /etc/login.gov/info/ that instructs provision.sh not
to complete the ASG lifecycle hook with ABANDON in the event that
provisioning fails.

But it's hard to remember this filename when you're racing the clock to
save the instance.

Add a new script, `id-asg-skip-abandon-hook`, that knows the name of
this file and will create it for you.