### PR TITLE
remove updates.atomicorp.com repository after installing ossec

### DIFF
--- a/identity_ossec/metadata.rb
+++ b/identity_ossec/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'identity-devops@login.gov'
 license          'CC0-1.0'
 description      'Installs/Configures identity_ossec'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'
 
 depends          'ossec'
 

--- a/identity_ossec/recipes/default.rb
+++ b/identity_ossec/recipes/default.rb
@@ -23,3 +23,7 @@ execute 'restart_rsyslog' do
   command 'service rsyslog restart'
   action :nothing
 end
+
+apt_repository 'ossec' do
+  action :remove
+end


### PR DESCRIPTION
Rather than compile `ossec` from source, removes the `atomicorp` repo from `/etc/apt/sources.list.d/` after `ossec` installation has completed. Since this is done in the base image, hosts should no longer break if `atomicorp` is serving up 404s.

Fixes #1856.