### PR TITLE
Upgrade to latest Passenger (6.0.4)

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -13,7 +13,7 @@ default[:passenger][:production][:log_path] = '/var/log/nginx'
 default[:passenger][:production][:status_server] = true
 
 default[:passenger][:production][:user] = node.fetch(:identity_shared_attributes).fetch(:production_user)
-default[:passenger][:production][:version] = '5.3.7'
+default[:passenger][:production][:version] = '6.0.4'
 
 # Allow our local /16 to proxy setting X-Forwarded-For
 # This is a little broad, but because we expect security group rules to prevent

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -25,6 +25,10 @@ bash "install passenger/nginx" do
   not_if "test -e #{nginx_path}/sbin/nginx"
 end
 
+execute "compile passenger agent" do
+ command "rbenv exec passenger-config compile-agent"
+end
+
 log_path = node[:passenger][:production][:log_path]
 
 directory log_path do


### PR DESCRIPTION
Fixes https://github.com/18F/identity-devops/issues/1294

Upgrades to the [latest passenger](https://github.com/phusion/passenger/releases) (6.0.4) and adds a step to compile the passenger agent binary in the recipe.

```
ubuntu@idp-i-0367a93e84daef2d4:~$ passenger-config compile-agent -h
Usage: passenger-config compile-agent [OPTIONS]

  Compile the Phusion Passenger agent binary. The agent binary is required for
  Phusion Passenger to function properly.

Options:
        --working-dir PATH           Store temporary files in the given
                                     directory, instead of creating one
        --auto                       Run in non-interactive mode. Default when
                                     stdin or stdout is not a TTY
        --optimize                   Compile agent with optimizations
    -f, --force                      Skip sanity checks
        --no-force-tip               Do not print any tips regarding the --force parameter
    -h, --help                       Show this help
```
