### PR TITLE
Build nginx with fips

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -7,7 +7,7 @@ openssl_installed_path = "/opt/openssl-#{openssl_version}"
 default[:passenger][:production][:path] = '/opt/nginx'
 default[:passenger][:production][:native_support_dir] = node.fetch(:passenger).fetch(:production).fetch(:path) + '/passenger-native-support'
 
-default[:passenger][:production][:configure_flags] = "--with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-ld-opt=\"-L #{openssl_installed_path}/lib\" --with-cc-opt=\"-I #{openssl_installed_path}/include\""
+default[:passenger][:production][:configure_flags] = "--with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-ld-opt=\"-L#{openssl_installed_path}/lib\" --with-cc-opt=\"-I#{openssl_installed_path}/include\""
 default[:passenger][:production][:log_path] = '/var/log/nginx'
 
 # Enable the status server on 127.0.0.1

--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -2,11 +2,12 @@ cache_dir = node.fetch(:identity_shared_attributes).fetch(:cache_dir)
 
 openssl_version = node.fetch(:identity_shared_attributes).fetch(:openssl_version)
 openssl_srcpath = "#{cache_dir}/openssl-#{openssl_version}"
+openssl_installed_path = "/opt/openssl-#{openssl_version}"
 
 default[:passenger][:production][:path] = '/opt/nginx'
 default[:passenger][:production][:native_support_dir] = node.fetch(:passenger).fetch(:production).fetch(:path) + '/passenger-native-support'
 
-default[:passenger][:production][:configure_flags] = "--with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-openssl=#{openssl_srcpath}"
+default[:passenger][:production][:configure_flags] = "--with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-ld-opt=\"-L #{openssl_installed_path}/lib\" --with-cc-opt=\"-I #{openssl_installed_path}/include\""
 default[:passenger][:production][:log_path] = '/var/log/nginx'
 
 # Enable the status server on 127.0.0.1

--- a/passenger/metadata.json
+++ b/passenger/metadata.json
@@ -29,5 +29,5 @@
     "passenger::daemon": "Install passenger/nginx as a service.",
     "passenger::standalone": "Install passenger/nginx and start it as standalone."
   },
-  "version": "0.0.8"
+  "version": "0.0.9"
 }


### PR DESCRIPTION
Passing `--with-openssl` to Passenger results in a new build of OpenSSL, without the configured defaults.  This patch tells the build to link against the existing, correctly built OpenSSL instead, saving 1 extra and misconfigured rebuild, restoring FIPS compliance.

```
root@idp-i-01b462.sjh:~# /opt/nginx/sbin/nginx -V
nginx version: nginx/1.17.3
built by gcc 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)
built with OpenSSL 1.0.2t-fips  10 Sep 2019 (running with OpenSSL 1.0.2n  7 Dec 2017)
TLS SNI support enabled
configure arguments: --prefix=/opt/nginx --with-http_ssl_module --with-http_v2_module --with-http_realip_module --with-http_gzip_static_module --with-http_stub_status_module --with-http_addition_module --with-cc-opt=-Wno-error --with-ld-opt= --add-module=/opt/ruby_build/builds/2.5.7/lib/ruby/gems/2.5.0/gems/passenger-6.0.4/src/nginx_module --with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-ld-opt=-L/opt/openssl-1.0.2t/lib --with-cc-opt=-I/opt/openssl-1.0.2t/include
```

Tested with:
```
rm /opt/nginx/sbin/nginx
chef-client --local-mode -c /etc/login.gov/repos/identity-devops/kitchen/chef-client.rb -o 'recipe[passenger::daemon]'
```