### PR TITLE
Force ruby_build to 1.2 version

### DIFF
--- a/identity_ruby/metadata.rb
+++ b/identity_ruby/metadata.rb
@@ -8,7 +8,7 @@ version '0.2.0'
 chef_version '>= 13.0' if respond_to?(:chef_version)
 
 depends 'identity_shared_attributes', '>= 0.1.2'
-depends 'ruby_build', '~> 1.2'
+depends 'ruby_build', '= 1.2'
 
 # The `source_url` points to the development repository for this cookbook.  A
 # `View Source` link will be displayed on this cookbook's page when uploaded to


### PR DESCRIPTION
Ruby build fails with OpenSSL on versions after 1.3.  Force berks to install only 1.2 version.