### PR TITLE
Resolves duplicate MIME warnings

### DIFF
--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -28,7 +28,7 @@ http {
   tcp_nopush <%= @passenger[:tcp_nopush] ? 'on' : 'off' %>;
   keepalive_timeout <%= @passenger[:keepalive_timeout] %>;
   gzip <%= @passenger[:gzip] ? 'on' : 'off' %>;
-  gzip_types text/plain text/html text/css application/xml application/javascript application/json image/jpg image/jpeg image/png image/gif image/svg+xml font/woff2 woff2;
+  gzip_types text/plain text/css application/xml application/javascript application/json image/jpg image/jpeg image/png image/gif image/svg+xml font/woff2 woff2;
 
   # Timeouts definition
   client_body_timeout   10;


### PR DESCRIPTION
- nginx: [warn] duplicate MIME type text/html in /opt/nginx/conf/nginx.conf:28
- http://nginx.org/en/docs/http/ngx_http_gzip_module.html
- gzip_types: Response with text/html type are always compressed