### PR TITLE
temporary syslog_rules override to prevent ossec alerts from nginx's access.log

### DIFF
--- a/identity_ossec/files/default/syslog_rules.xml
+++ b/identity_ossec/files/default/syslog_rules.xml
@@ -1,0 +1,721 @@
+<!-- @(#) $Id: syslog_rules.xml,v 1.22 2010/11/25 17:06:17 ddp Exp $
+  -  Official Generic Syslog rules for OSSEC.
+  -
+  -  Copyright (C) 2009 Trend Micro Inc.
+  -  All rights reserved.
+  -
+  -  This program is a free software; you can redistribute it
+  -  and/or modify it under the terms of the GNU General Public
+  -  License (version 2) as published by the FSF - Free Software
+  -  Foundation.
+  -
+  -  License details: http://www.ossec.net/en/licensing.html
+  -->
+  
+
+<!-- Default variables for the SYSLOG rules. -->
+
+<!-- Bad words matching. Any log containing these messages
+  -  will be triggered.
+  -->
+<var name="BAD_WORDS">core_dumped|failure|error|attack| bad |illegal |denied|refused|unauthorized|fatal|failed|Segmentation Fault|Corrupted</var>
+
+
+<!-- Syslog errors. -->
+<group name="syslog,errors,">
+  <rule id="1001" level="2">
+    <pcre2>^Couldn't open /etc/securetty</pcre2>
+    <description>File missing. Root access unrestricted.</description>
+  </rule>
+
+  <rule id="1002" level="2">
+    <pcre2>$BAD_WORDS</pcre2>
+    <options>alert_by_email</options>
+    <description>Unknown problem somewhere in the system.</description>
+  </rule>
+
+  <rule id="1004" level="5">
+    <pcre2>^exiting on signal</pcre2>
+    <description>Syslogd exiting (logging stopped).</description>
+  </rule>
+  
+  <rule id="1005" level="5">
+    <program_name_pcre2>syslogd</program_name_pcre2>
+    <pcre2>^restart</pcre2>
+    <description>Syslogd restarted.</description>
+  </rule>
+
+  <rule id="1006" level="5">
+    <pcre2>^syslogd \S+ restart</pcre2>
+    <description>Syslogd restarted.</description>
+  </rule>
+  
+  <rule id="1007" level="7">
+    <pcre2>file system full|No space left on device</pcre2>
+    <description>File system full.</description>
+    <group>low_diskspace,</group>
+  </rule>
+
+  <rule id="1008" level="5">
+    <pcre2>killed by SIGTERM</pcre2>
+    <description>Process exiting (killed).</description>
+    <group>service_availability,</group>
+  </rule>
+
+  <rule id="1009" level="0">
+    <if_sid>1002</if_sid>
+    <pcre2>terminated without error|can't verify hostname: getaddrinfo|</pcre2>
+    <pcre2>PPM exceeds tolerance</pcre2>
+    <description>Ignoring known false positives on rule 1002..</description>
+  </rule>
+
+  <rule id="1010" level="5">
+    <pcre2>segfault at </pcre2>
+    <description>Process segfaulted.</description>
+    <group>service_availability,</group>
+  </rule>
+</group> <!-- SYSLOG,ERRORS -->
+
+
+
+<!-- NFS messages -->
+<group name="syslog,nfs,">
+  <!-- XXX All These NFS rules need to be fixed. -->
+  <rule id="2100" level="0" noalert="1">
+    <program_name_pcre2>^automount|^mount</program_name_pcre2>
+    <description>NFS rules grouped.</description>
+  </rule>
+  
+  <rule id="2101" level="4">
+    <if_sid>2100</if_sid>
+    <pcre2>nfs: mount failure</pcre2>
+    <description>Unable to mount the NFS share.</description>
+  </rule>
+
+  <rule id="2102" level="4">
+    <if_sid>2100</if_sid>
+    <pcre2>reason given by server: Permission denied</pcre2>
+    <description>Unable to mount the NFS directory.</description>
+  </rule>
+ 
+  <rule id="2103" level="4">
+    <pcre2>^rpc\.mountd: refused mount request from</pcre2>
+    <description>Unable to mount the NFS directory.</description>
+  </rule>
+
+  <rule id="2104" level="2">
+    <if_sid>2100</if_sid>
+    <pcre2>lookup for \S+ failed</pcre2>
+    <description>Automount informative message</description>
+  </rule>
+</group> <!-- SYSLOG,NFS -->
+  
+  
+
+<!-- xinetd messages -->  
+<group name="syslog,xinetd,">
+  <rule id="2301" level="10">
+    <pcre2>^Deactivating service </pcre2>
+    <description>Excessive number connections to a service.</description>
+  </rule>
+</group> <!-- SYSLOG,XINETD -->
+
+
+
+<!-- Access control messages -->
+<group name="syslog,access_control,">
+  <rule id="2501" level="5">
+    <pcre2>FAILED LOGIN |authentication failure|</pcre2>
+    <pcre2>Authentication failed for|invalid password for|</pcre2>
+    <pcre2>LOGIN FAILURE|auth failure: |authentication error|</pcre2>
+    <pcre2>authinternal failed|Failed to authorize|</pcre2>
+    <pcre2>Wrong password given for|login failed|Auth: Login incorrect|</pcre2>
+    <pcre2>Failed to authenticate user</pcre2>
+    <group>authentication_failed,</group>
+    <description>User authentication failure.</description>
+  </rule>
+
+  <rule id="2502" level="10">
+    <pcre2>more authentication failures;|REPEATED login failures</pcre2>
+    <description>User missed the password more than one time</description>
+    <group>authentication_failed,</group>
+  </rule>
+
+  <rule id="2503" level="5">
+    <pcre2>^refused connect from|</pcre2>
+    <pcre2>^libwrap refused connection|</pcre2>
+    <pcre2>Connection from \S+ denied</pcre2>
+    <description>Connection blocked by Tcp Wrappers.</description>
+    <group>access_denied,</group>
+  </rule>
+
+  <rule id="2504" level="9">
+    <pcre2>ILLEGAL ROOT LOGIN|ROOT LOGIN REFUSED</pcre2>
+    <description>Illegal root login. </description>
+    <group>invalid_login,</group>
+  </rule>
+
+  <rule id="2505" level="3">
+    <pcre2>^ROOT LOGIN  on</pcre2>
+    <description>Physical root login.</description>
+  </rule>  
+
+  <rule id="2506" level="3">
+    <pcre2>^Authentication passed</pcre2>
+    <description>Pop3 Authentication passed.</description>
+  </rule>
+
+  <rule id="2507" level="0">
+    <decoded_as>openldap</decoded_as>
+    <description>OpenLDAP group.</description>
+  </rule>
+
+  <rule id="2508" level="3">
+    <if_sid>2507</if_sid>
+    <pcre2>ACCEPT from</pcre2>
+    <description>OpenLDAP connection open.</description>
+  </rule>
+
+  <rule id="2509" level="5" timeframe="10" frequency="0">
+    <if_sid>2507</if_sid>
+    <if_matched_sid>2508</if_matched_sid>
+    <same_id />
+    <pcre2>RESULT tag=97 err=49</pcre2>
+    <description>OpenLDAP authentication failed.</description>
+  </rule>
+
+</group> <!-- SYSLOG,ACESSCONTROL -->
+
+
+
+<!-- rshd -->
+<group name="syslog,access_control,">
+  <rule id="2550" level="0" noalert="1">
+    <decoded_as>rshd</decoded_as>
+    <description>rshd messages grouped.</description>
+  </rule>
+
+  <rule id="2551" level="10">
+    <if_sid>2550</if_sid>
+    <pcre2>^Connection from \S+ on illegal port$</pcre2>
+    <description>Connection to rshd from unprivileged port. Possible network scan.</description>
+    <group>connection_attempt,</group>
+  </rule>
+</group>
+
+
+
+<!-- Mail/Procmail messages -->
+<group name="syslog,mail,">
+  <rule id="2701" level="0">
+    <program_name_pcre2>^procmail</program_name_pcre2>
+    <description>Ignoring procmail messages.</description>
+  </rule>
+</group> <!-- SYSLOG,SENDMAIL -->
+  
+
+
+<!-- Smartd messages -->
+<group name="syslog,smartd,">
+  <rule id="2800" level="0" noalert="1">
+    <program_name_pcre2>^smart</program_name_pcre2>
+    <description>Pre-match rule for smartd.</description>
+  </rule>
+  
+  <rule id="2801" level="0">
+    <if_sid>2800</if_sid>
+    <pcre2>No configuration file /etc/smartd\.conf found</pcre2>
+    <description>Smartd Started but not configured</description>
+  </rule>
+
+  <rule id="2802" level="0">
+    <if_sid>2800</if_sid>
+    <pcre2>Unable to register ATA device</pcre2>
+    <description>Smartd configuration problem</description>
+  </rule>
+
+  <rule id="2803" level="0">
+    <if_sid>2800</if_sid>
+    <pcre2>No such device or address</pcre2>
+    <description>Device configured but not available to Smartd</description>
+  </rule>  
+</group> <!-- SYSLOG,SMARTD -->
+
+
+
+<!-- Linux Kernel messages -->
+<group name="syslog,linuxkernel,">
+  <rule id="5100" level="0" noalert="1">
+    <program_name_pcre2>^kernel</program_name_pcre2>
+    <description>Pre-match rule for kernel messages</description>
+  </rule>
+
+  <rule id="5101" level="0">
+    <if_sid>5100</if_sid>
+    <pcre2>PCI: if you experience problems, try using option</pcre2>
+    <description>Informative message from the kernel.</description>
+  </rule>
+
+  <rule id="5102" level="0">
+    <if_sid>5100</if_sid>
+    <pcre2>modprobe: Can't locate module sound</pcre2>
+    <description>Informative message from the kernel</description>
+  </rule>
+  
+  <rule id="5103" level="9">
+    <if_sid>5100</if_sid>
+    <pcre2>Oversized packet received from</pcre2>
+    <description>Error message from the kernel. </description>
+    <description>Ping of death attack.</description>
+  </rule>  
+
+  <rule id="5104" level="8">
+    <if_sid>5100</if_sid>
+    <pcre2>Promiscuous mode enabled|</pcre2>
+    <pcre2>device \S+ entered promiscuous mode</pcre2>
+    <description>Interface entered in promiscuous(sniffing) mode.</description>
+    <group>promisc,</group>
+  </rule>
+
+  <rule id="5105" level="0">
+    <if_sid>5100</if_sid>
+    <pcre2>end_request: I/O error, dev fd0, sector 0|</pcre2>
+    <pcre2>Buffer I/O error on device fd0, logical block 0</pcre2>
+    <description>Invalid request to /dev/fd0 (bug on the kernel).</description>
+  </rule>
+
+  <rule id="5106" level="0">
+    <if_sid>5100</if_sid>
+    <pcre2>svc: unknown program 100227 \(me 100003\)</pcre2>
+    <description>NFS incompatibility between Linux and Solaris.</description>
+  </rule>
+
+  <rule id="5107" level="0">
+    <if_sid>5100</if_sid>
+    <pcre2>svc: bad direction </pcre2>
+    <description>NFS incompatibility between Linux and Solaris.</description>
+  </rule>
+
+  <rule id="5108" level="12">
+    <if_sid>5100</if_sid>
+    <pcre2>Out of Memory: </pcre2>
+    <description>System running out of memory. </description>
+    <description>Availability of the system is in risk.</description>
+    <group>service_availability,</group>
+  </rule>
+
+  <rule id="5109" level="4">
+    <if_sid>5100</if_sid>
+    <pcre2>I/O error: dev |end_request: I/O error, dev</pcre2>
+    <description>Kernel Input/Output error</description>
+  </rule>
+
+  <rule id="5110" level="4">
+    <if_sid>5100</if_sid>
+    <pcre2>Forged DCC command from</pcre2>
+    <description>IRC misconfiguration</description>
+  </rule>
+
+  <rule id="5111" level="0">
+    <if_sid>5100</if_sid>
+    <pcre2>ipw2200: Firmware error detected\.| ACPI Error</pcre2>
+    <description>Kernel device error.</description>
+  </rule>
+
+  <rule id="5112" level="0">
+    <if_sid>5100</if_sid>
+    <pcre2>usbhid: probe of</pcre2>
+    <description>Kernel usbhid probe error (ignored).</description>
+  </rule>
+
+  <rule id="5113" level="7">
+    <if_sid>5100</if_sid>
+    <pcre2>Kernel log daemon terminating</pcre2>
+    <group>system_shutdown,</group>
+    <description>System is shutting down.</description>
+  </rule>
+
+  <rule id="5130" level="7">
+    <if_sid>5100</if_sid>
+    <pcre2>ADSL line is down</pcre2>
+    <description>Monitor ADSL line is down.</description>
+  </rule>
+  
+  <rule id="5131" level="3">
+    <if_sid>5100</if_sid>
+    <pcre2>ADSL line is up</pcre2>
+    <description>Monitor ADSL line is up.</description>
+  </rule>                         
+
+  <rule id="5200" level="0">
+    <pcre2>^hpiod: unable to ParDevice</pcre2>
+    <description>Ignoring hpiod for producing useless logs.</description>
+  </rule>
+</group> <!-- SYSLOG,LINUXKERNEL -->
+
+
+
+<!-- Cron messages -->
+<group name="syslog,cron,">
+  <rule id="2830" level="0">
+    <program_name_pcre2>crond|crontab</program_name_pcre2>
+    <description>Crontab rule group.</description>
+  </rule>
+  
+  <rule id="2831" level="0">
+    <if_sid>2830</if_sid>
+    <pcre2>^unable to exec</pcre2>
+    <description>Wrong crond configuration</description>
+  </rule>
+  
+  <rule id="2834" level="5">
+    <if_sid>2830</if_sid>
+    <pcre2>BEGIN EDIT</pcre2>
+    <description>Crontab opened for editing.</description>
+  </rule>
+  
+  <rule id="2832" level="5">
+    <if_sid>2830</if_sid>
+    <pcre2>REPLACE</pcre2>
+    <description>Crontab entry changed.</description>
+  </rule>
+
+  <rule id="2833" level="8">
+    <if_sid>2832</if_sid>
+    <pcre2>^\(root\)</pcre2>
+    <description>Root's crontab entry changed.</description>
+  </rule>
+
+</group> <!-- SYSLOG,CRON -->
+
+
+
+<!-- Su messages -->
+<group name="syslog, su,">
+  <rule id="5300" level="0" noalert="1">
+    <decoded_as>su</decoded_as>
+    <description>Initial grouping for su messages.</description>
+  </rule>
+  
+  <rule id="5301" level="5">
+   <if_sid>5300</if_sid>
+   <pcre2>authentication failure; |failed|BAD su|^-</pcre2>
+   <description>User missed the password to change UID (user id).</description> 
+   <group>authentication_failed,</group>
+  </rule>
+
+  <rule id="5302" level="9">
+    <if_sid>5301</if_sid>
+    <user_pcre2>^root</user_pcre2>
+    <description>User missed the password to change UID to root.</description>
+    <group>authentication_failed,</group>
+  </rule>
+
+  <rule id="5303" level="3">
+    <if_sid>5300</if_sid>
+    <pcre2>session opened for user root|^'su root'|</pcre2>
+    <pcre2>^\+ \S+ \S+[()*+,.:;\<=>?\[\]!"'#%&$|{}-]root$|^\S+ to root on|^SU \S+ \S+ \+ \S+ \S+-root$</pcre2>
+    <description>User successfully changed UID to root.</description>
+    <group>authentication_success,</group>
+  </rule>
+
+  <rule id="5304" level="3">
+    <if_sid>5300</if_sid>
+    <pcre2>session opened for user|succeeded for|</pcre2>
+    <pcre2>^\+|^\S+ to |^SU \S+ \S+ \+ </pcre2>
+    <description>User successfully changed UID.</description>
+    <group>authentication_success,</group>
+  </rule>
+
+  <rule id="5305" level="4">
+    <if_sid>5303, 5304</if_sid>
+    <if_fts></if_fts>
+    <options>alert_by_email</options>
+    <description>First time (su) is executed by user.</description>
+  </rule>
+
+  <rule id="5306" level="0">
+    <if_sid>5300</if_sid>
+    <pcre2>unknown class</pcre2>
+    <info>OpenBSD uses login classes, and an inappropriate login class was used.</info>
+    <description>A user has attempted to su to an unknown class.</description>
+  </rule>
+
+</group> <!-- SYSLOG,SU -->
+
+
+
+<!-- Tripwire messages -->
+<group name="syslog,tripwire,">
+  <rule id="7101" level="8">
+    <pcre2>Integrity Check failed: File could not</pcre2>
+    <description>Problems with the tripwire checking</description>
+  </rule>
+</group> <!-- SYSLOG,TRIPWIRE -->
+
+
+
+<!-- Adduser messages -->
+<group name="syslog,adduser">
+  <rule id="5901" level="8">
+    <pcre2>^new group</pcre2>
+    <description>New group added to the system</description>
+  </rule>
+
+  <rule id="5902" level="8">
+    <pcre2>^new user|^new account added</pcre2>
+    <description>New user added to the system</description>
+  </rule>
+
+  <rule id="5903" level="2">
+    <pcre2>^delete user|^account deleted|^remove group</pcre2>
+    <description>Group (or user) deleted from the system</description>
+  </rule>
+
+  <rule id="5904" level="8">
+    <pcre2>^changed user</pcre2>
+    <description>Information from the user was changed</description>
+  </rule>
+
+  <rule id="5905" level="0">
+    <program_name_pcre2>useradd</program_name_pcre2>
+    <pcre2>failed adding user </pcre2>
+    <description>useradd failed.</description>
+  </rule>
+
+</group> <!-- SYSLOG,ADDUSER -->
+
+
+
+<!-- Sudo messages -->
+<group name="syslog,sudo">
+  <rule id="5400" level="0" noalert="1">
+    <decoded_as>sudo</decoded_as>
+    <description>Initial group for sudo messages</description>
+  </rule>
+  
+  <rule id="5401" level="5">
+    <if_sid>5400</if_sid>
+    <pcre2>incorrect password attempt</pcre2>
+    <description>Failed attempt to run sudo</description>
+  </rule>
+
+  <rule id="5402" level="3">
+    <if_sid>5400</if_sid>
+    <pcre2> ; USER=root ; COMMAND=| ; USER=root ; TSID=\S+ ; COMMAND=</pcre2>
+    <description>Successful sudo to ROOT executed</description>
+  </rule>
+
+  <rule id="5403" level="4">
+    <if_sid>5400</if_sid>
+    <options>alert_by_email</options>
+    <if_fts></if_fts>
+    <description>First time user executed sudo.</description>
+  </rule>
+
+  <rule id="5404" level="10">
+    <if_sid>5401</if_sid>
+    <pcre2>3 incorrect password attempts</pcre2>
+    <description>Three failed attempts to run sudo</description>
+  </rule>
+
+  <rule id="5405" level="5">
+    <if_sid>5400</if_sid>
+    <pcre2>user NOT in sudoers</pcre2>
+    <description>Unauthorized user attempted to use sudo.</description>
+  </rule>
+
+</group> <!-- SYSLOG, SUDO -->
+
+
+<!-- PPTP messages -->
+<group name="syslog,pptp">
+  <rule id="9100" level="0" noalert="1">
+    <program_name_pcre2>^pptpd</program_name_pcre2>
+    <description>PPTPD messages grouped</description>
+  </rule>
+  
+  <rule id="9101" level="0">
+    <if_sid>9100</if_sid>
+    <pcre2>^GRE: \S+ from \S+ failed: status = -1 </pcre2>
+    <description>PPTPD failed message (communication error)</description>
+    <info type="link">http://poptop.sourceforge.net/dox/gre-protocol-unavailable.phtml</info>
+  </rule>
+  
+  <rule id="9102" level="0">
+    <if_sid>9100</if_sid>
+    <pcre2>^tcflush failed: Bad file descriptor</pcre2>
+    <description>PPTPD communication error</description>
+  </rule>
+</group>
+
+
+
+<!-- Syslog FTS -->
+<group name="syslog,fts,">
+  <rule id="10100" level="4">
+    <if_group>authentication_success</if_group>
+    <options>alert_by_email</options>
+    <if_fts></if_fts>
+    <group>authentication_success</group>
+    <description>First time user logged in.</description>
+  </rule>
+</group>
+
+                
+<group name="syslog,squid,">
+  <rule id="9200" level="0" noalert="1">
+    <program_name_pcre2>^squid</program_name_pcre2>
+    <description>Squid syslog messages grouped</description>
+  </rule>
+
+  <rule id="9201" level="0">
+    <if_sid>9200</if_sid>
+    <pcre2>^ctx: enter level|^sslRead|^urlParse: Illegal |</pcre2>
+    <pcre2>^httpReadReply: Request not yet |^httpReadReply: Excess data</pcre2>
+    <description>Squid debug message</description>
+  </rule>
+</group>
+
+
+<group name="syslog,dpkg,">
+  <rule id="2900" level="0">
+    <decoded_as>windows-date-format</decoded_as>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} startup |</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} status |</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} remove |</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} configure |</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} install |</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} purge |</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} trigproc |</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} conffile |</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} upgrade </pcre2>
+    <description>Dpkg (Debian Package) log.</description>
+  </rule>
+  
+  <rule id="2901" level="3">
+    <if_sid>2900</if_sid>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} install</pcre2>
+    <description>New dpkg (Debian Package) requested to install.</description>
+  </rule>
+
+ <rule id="2902" level="7">
+    <if_sid>2900</if_sid>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} status installed</pcre2>
+    <description>New dpkg (Debian Package) installed.</description>
+    <group>config_changed,</group>
+  </rule>
+
+  <rule id="2903" level="7">
+    <if_sid>2900</if_sid>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} remove|</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} purge</pcre2>
+    <description>Dpkg (Debian Package) removed.</description>
+    <group>config_changed,</group>
+  </rule>
+</group>
+
+
+<group name="syslog,yum,">
+  <rule id="2930" level="0">
+    <program_name_pcre2>^yum</program_name_pcre2>
+    <description>Yum logs.</description>
+  </rule>
+
+  <rule id="2931" level="0">
+    <hostname_pcre2>yum\.log$</hostname_pcre2>
+    <pcre2>^Installed|^Updated|^Erased</pcre2>
+    <description>Yum logs.</description>
+  </rule>
+
+  <rule id="2932" level="7">
+    <if_sid>2930,2931</if_sid>
+    <pcre2>^Installed</pcre2>
+    <group>config_changed,</group>
+    <description>New Yum package installed.</description>
+  </rule>
+
+  <rule id="2933" level="7">
+    <if_sid>2930,2931</if_sid>
+    <pcre2>^Updated</pcre2>
+    <group>config_changed,</group>
+    <description>Yum package updated.</description>
+  </rule>
+
+  <rule id="2934" level="7">
+    <if_sid>2930,2931</if_sid>
+    <pcre2>^Erased</pcre2>
+    <group>config_changed,</group>
+    <description>Yum package deleted.</description>
+  </rule>
+
+  <!-- SCSI CONTROLLER -->
+  <rule id="2935" level="0" noalert="1">
+    <if_sid>5100</if_sid>
+    <id_pcre2>mptscsih</id_pcre2>
+    <description>Grouping for the mptscrih rules.</description>
+  </rule>
+
+  <rule id="2936" level="0" noalert="1">
+    <if_sid>5100</if_sid>
+    <id_pcre2>mptbase</id_pcre2>
+    <description>Grouping for the mptbase rules.</description>
+  </rule>
+
+  <rule id="2937" level="12">
+    <if_sid>2935</if_sid>
+    <status_pcre2>FAILED</status_pcre2>
+    <description>Possible Disk failure. SCSI controller error.</description>
+  </rule>
+
+  <rule id="2938" level="12">
+    <if_sid>2936</if_sid>
+    <action>failed</action>
+    <description>SCSI RAID ARRAY ERROR, drive failed.</description>
+  </rule>
+
+  <rule id="2939" level="12">
+    <if_sid>2936</if_sid>
+    <action>degraded</action>
+    <description>SCSI RAID is now in a degraded status.</description>
+  </rule>
+
+  <rule id="2940" level="0">
+    <program_name_pcre2>^NetworkManager</program_name_pcre2>
+    <description>NetworkManager grouping.</description>
+  </rule>
+
+  <rule id="2941" level="3">
+    <if_sid>2940</if_sid>
+    <pcre2> No chain/target/match by that name\.$</pcre2>
+    <description>Incorrect chain/target/match.</description>
+  </rule>
+
+  <rule id="2942" level="0">
+    <if_sid>1002</if_sid>
+    <pcre2>g_slice_set_config: assertion `sys_page_size == 0' failed</pcre2>
+    <description>Uninteresting gnome error.</description>
+  </rule>
+
+  <rule id="2943" level="0">
+    <pcre2>^nouveau </pcre2>
+    <description>nouveau driver grouping</description>
+  </rule>
+
+  <rule id="2944" level="1">
+    <if_sid>2943</if_sid>
+    <pcre2> DATA_ERROR BEGIN_END_ACTIVE$| DATA_ERROR$</pcre2>
+    <description>Uninteresting nouveau error.</description>
+  </rule>
+
+  <rule id="2945" level="4">
+    <program_name_pcre2>^rsyslogd</program_name_pcre2>
+    <pcre2>^imuxsock begins to drop messages </pcre2>
+    <info>https://isc.sans.edu/diary/Are+you+losing+system+logging+information+%28and+don%27t+know+it%29%3F/15106</info>
+    <description>rsyslog may be dropping messages due to rate-limiting.</description>
+  </rule>
+
+</group>
+
+
+<!-- EOF -->

--- a/identity_ossec/recipes/default.rb
+++ b/identity_ossec/recipes/default.rb
@@ -9,6 +9,14 @@
 
 include_recipe 'ossec'
 
+# custom syslog_rules which removes rule 1003
+cookbook_file '/var/ossec/rules/syslog_rules.xml' do
+  source 'syslog_rules.xml'
+  owner 'root'
+  group 'ossec'
+  mode '0550'
+end
+
 execute '/var/ossec/bin/ossec-control enable client-syslog' do
   not_if "ps gaxuwww | grep ossec-csyslogd | grep -v grep"
   notifies :restart, 'service[ossec]'


### PR DESCRIPTION
After `ossec` is installed/configured via the `ossec` cookbook (in `identity_ossec`), override the default `syslog_rules.xml` with a custom one built here, which removes alerting on Rule 1003 (RFC5424) for syslog messages >2048 bytes in length.

Addresses https://github.com/18F/identity-devops/issues/2562