### PR TITLE
Stop NGINX cookie logging and enable longer syslog limit rule in OSSEC

### DIFF
--- a/identity_ossec/files/default/syslog_rules.xml
+++ b/identity_ossec/files/default/syslog_rules.xml
@@ -34,6 +34,11 @@
     <description>Unknown problem somewhere in the system.</description>
   </rule>
 
+  <rule id="1003" level="13" maxsize="2048">
+    <!-- Override from default of 1023 -->
+    <description>Non standard syslog message (message size > 2048).</description>
+  </rule>
+
   <rule id="1004" level="5">
     <pcre2>^exiting on signal</pcre2>
     <description>Syslogd exiting (logging stopped).</description>

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -91,7 +91,7 @@ http {
                   'http_user_agent="$http_user_agent" nginx_version="$nginx_version" '
                   'http_x_forwarded_for="$http_x_forwarded_for" uri_query="$query_string" '
                   'uri_path="$uri" http_method="$request_method" '
-                  'response_time="$upstream_response_time" cookie="$http_cookie" '
+                  'response_time="$upstream_response_time" '
                   'request_time="$request_time" request="$request" '
                   'http_x_amzn_trace_id="http_x_amzn_trace_id"';
 


### PR DESCRIPTION
Addresses https://github.com/18F/identity-devops/issues/2566

* Removes cookie log from `/var/log/nginx/access.log` for improved security and shorter log lines
* Keeps `syslog_rules.xml` override but adds slightly longer max log line limit matching the RFC "SHOULD" recommended minimum of 2048 bytes per line 

* Tested `base` and `rails` AMI builds - Working (see bottom)
* Sample `access.log` line WITHOUT cookies:
~~~
hostname="idp.pauldoom.identitysandbox.gov" dest_port="443" dest_ip="172.16.33.141" src="98.240.210.150" src_ip="172.16.33.228" lb_if_proxied="172.16.33.228" user="-" time_local="16/Jun/2020:04:25:41 +0000" protocol="HTTP/1.1" status="200" bytes_out="0" bytes_in="0" http_referer="https://idp.pauldoom.identitysandbox.gov/account" http_user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36" nginx_version="1.17.3" http_x_forwarded_for="98.240.210.150" uri_query="-" uri_path="/analytics" http_method="POST" response_time="0.044" request_time="0.048" request="POST /analytics HTTP/1.1" http_x_amzn_trace_id="http_x_amzn_trace_id"
~~~
* Verified `access.log` still being ingested by CloudWatch and Filebeat and appearing as before in CloudWatch UI and Kibana
* Verified new syslog rules in place and OSSEC running

Sample AMI build output:

![Screen Shot 2020-06-15 at 17 31 20](https://user-images.githubusercontent.com/59626817/84731819-b912ea80-af5f-11ea-9c46-72c741879c99.png)
