### PR TITLE
Turn off syslog_rules.xml rule 1003

### DIFF
--- a/identity_ossec/files/default/syslog_rules.xml
+++ b/identity_ossec/files/default/syslog_rules.xml
@@ -34,10 +34,11 @@
     <description>Unknown problem somewhere in the system.</description>
   </rule>
 
+  <!-- # Rule disabled 06/2020 - Triggering on logs not handled by syslog that
+       # have ligitimate lines over 2048 bytes
   <rule id="1003" level="13" maxsize="2048">
-    <!-- Override from default of 1023 -->
     <description>Non standard syslog message (message size > 2048).</description>
-  </rule>
+  </rule> -->
 
   <rule id="1004" level="5">
     <pcre2>^exiting on signal</pcre2>


### PR DESCRIPTION
The longer limit (2048 instead of 1023 bytes) still triggers on some messages
from SSM Agent and NGINX.  After review we did not find cases where the lines
triggering the warning were actually passing through `syslogd`.   Our SSP
states use of CloudWatch Logs and ELK (with logs ingested by FileBeat), neither
of which will truncate these longer messages.

This PR disables the rule permanently.

See https://gsa-tts.slack.com/archives/C16RSBG49/p1593011646479700 for context.

Test run from IdP instance:
~~~
curl -k https://127.0.0.1/?thisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverendsthisisthequerythatneverends
~~~

Result: Query logged to `/var/log/nging/access.log` but no OSSEC warning in `/var/log/messages`.