### PR TITLE
Upgrade passenger version

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -14,7 +14,7 @@ default[:passenger][:production][:log_path] = '/var/log/nginx'
 default[:passenger][:production][:status_server] = true
 
 default[:passenger][:production][:user] = node.fetch(:identity_shared_attributes).fetch(:production_user)
-default[:passenger][:production][:version] = '6.0.4'
+default[:passenger][:production][:version] = '6.0.6'
 
 # Allow our local /16 to proxy setting X-Forwarded-For
 # This is a little broad, but because we expect security group rules to prevent


### PR DESCRIPTION
Passenger to 6.0.6
This will update nginx to 1.18.0

Issue https://github.com/18F/identity-security-private/issues/1778