### PR TITLE
add fips mode to nginx/passenger

### DIFF
--- a/identity_fips_openssl/recipes/default.rb
+++ b/identity_fips_openssl/recipes/default.rb
@@ -58,6 +58,12 @@ execute 'compile_openssl_source' do
   not_if { ::File.directory?(node['identity_fips_openssl']['openssl']['prefix']) }
 end
 
+execute 'link certs dir' do
+  cwd node['identity_fips_openssl']['openssl']['prefix']
+  command "rmdir ssl/certs ; ln -s /usr/lib/ssl/certs ssl/certs"
+  not_if { ::File.symlink?("#{node['identity_fips_openssl']['openssl']['prefix']}/ssl/certs")}
+end
+
 #record binary location for chef deployment to access
 directory '/etc/login.gov/info' do
   owner 'root'

--- a/identity_ruby/recipes/default.rb
+++ b/identity_ruby/recipes/default.rb
@@ -24,14 +24,17 @@ openssl_srcpath = "#{cache_dir}/openssl-#{node.fetch(:identity_shared_attributes
 # We would use RUBY_CONFIGURE_OPTS except for
 # https://github.com/poise/poise-ruby-build/issues/9
 
+ENV['CONFIGURE_OPTS'] = "--with-openssl-dir=#{openssl_srcpath}"
 ENV['RUBY_CONFIGURE_OPTS'] = "--with-openssl-dir=#{openssl_srcpath}"
 
-  
 node.fetch('identity_ruby').fetch('ruby_versions').each do |version|
   ruby_build_ruby version do
     prefix_path "#{rbenv_root}/builds/#{version}"
     notifies :run, 'execute[rbenv rehash]'
-    environment ({'RUBY_CONFIGURE_OPTS' => "--with-openssl-dir=#{openssl_srcpath}"})
+    environment({
+      'CONFIGURE_OPTS' => "--with-openssl-dir=#{openssl_srcpath}",
+      'RUBY_CONFIGURE_OPTS' => "--with-openssl-dir=#{openssl_srcpath}"
+    })
   end
 
   # if version follow standard x.x.x version number, create alias at x.x so

--- a/identity_ruby/recipes/default.rb
+++ b/identity_ruby/recipes/default.rb
@@ -28,8 +28,8 @@ ENV['CONFIGURE_OPTS'] = "--with-openssl-dir=#{openssl_srcpath}"
 ENV['RUBY_CONFIGURE_OPTS'] = "--with-openssl-dir=#{openssl_srcpath}"
 
 node.fetch('identity_ruby').fetch('ruby_versions').each do |version|
-  ruby_build_ruby version do
-    prefix_path "#{rbenv_root}/builds/#{version}"
+  execute "build #{version} with #{openssl_srcpath}" do
+    command "/usr/local/bin/ruby-build \"#{version}\" \"/opt/ruby_build/builds/#{version}\""
     notifies :run, 'execute[rbenv rehash]'
     environment({
       'CONFIGURE_OPTS' => "--with-openssl-dir=#{openssl_srcpath}",

--- a/identity_ruby/recipes/default.rb
+++ b/identity_ruby/recipes/default.rb
@@ -31,6 +31,7 @@ node.fetch('identity_ruby').fetch('ruby_versions').each do |version|
   ruby_build_ruby version do
     prefix_path "#{rbenv_root}/builds/#{version}"
     notifies :run, 'execute[rbenv rehash]'
+    environment ({'RUBY_CONFIGURE_OPTS' => "--with-openssl-dir=#{openssl_srcpath}"})
   end
 
   # if version follow standard x.x.x version number, create alias at x.x so

--- a/identity_ruby/recipes/default.rb
+++ b/identity_ruby/recipes/default.rb
@@ -19,14 +19,7 @@ link "#{rbenv_root}/versions" do
   to '/opt/ruby_build/builds'
 end
 
-cache_dir = node.fetch(:identity_shared_attributes).fetch('cache_dir')
-openssl_srcpath = "#{cache_dir}/openssl-#{node.fetch(:identity_shared_attributes).fetch(:openssl_version)}"
 openssl_path = "/opt/openssl-#{node[:identity_shared_attributes][:openssl_version]}"
-# We would use RUBY_CONFIGURE_OPTS except for
-# https://github.com/poise/poise-ruby-build/issues/9
-
-ENV['CONFIGURE_OPTS'] = "--with-openssl-dir=#{openssl_srcpath}"
-ENV['RUBY_CONFIGURE_OPTS'] = "--with-openssl-dir=#{openssl_srcpath}"
 
 node.fetch('identity_ruby').fetch('ruby_versions').each do |version|
   execute "build #{version} with #{openssl_path}" do

--- a/identity_ruby/recipes/default.rb
+++ b/identity_ruby/recipes/default.rb
@@ -29,7 +29,7 @@ ENV['CONFIGURE_OPTS'] = "--with-openssl-dir=#{openssl_srcpath}"
 ENV['RUBY_CONFIGURE_OPTS'] = "--with-openssl-dir=#{openssl_srcpath}"
 
 node.fetch('identity_ruby').fetch('ruby_versions').each do |version|
-  execute "build #{version} with #{openssl_srcpath}" do
+  execute "build #{version} with #{openssl_path}" do
     command "/usr/local/bin/ruby-build \"#{version}\" \"/opt/ruby_build/builds/#{version}\""
     notifies :run, 'execute[rbenv rehash]'
     environment({

--- a/identity_ruby/recipes/default.rb
+++ b/identity_ruby/recipes/default.rb
@@ -21,6 +21,7 @@ end
 
 cache_dir = node.fetch(:identity_shared_attributes).fetch('cache_dir')
 openssl_srcpath = "#{cache_dir}/openssl-#{node.fetch(:identity_shared_attributes).fetch(:openssl_version)}"
+openssl_path = "/opt/openssl-#{node[:identity_shared_attributes][:openssl_version]}"
 # We would use RUBY_CONFIGURE_OPTS except for
 # https://github.com/poise/poise-ruby-build/issues/9
 
@@ -32,8 +33,10 @@ node.fetch('identity_ruby').fetch('ruby_versions').each do |version|
     command "/usr/local/bin/ruby-build \"#{version}\" \"/opt/ruby_build/builds/#{version}\""
     notifies :run, 'execute[rbenv rehash]'
     environment({
-      'CONFIGURE_OPTS' => "--with-openssl-dir=#{openssl_srcpath}",
-      'RUBY_CONFIGURE_OPTS' => "--with-openssl-dir=#{openssl_srcpath}"
+      'CONFIGURE_OPTS' => "--with-openssl-dir=#{openssl_path}",
+      'RUBY_CONFIGURE_OPTS' => "--with-openssl-dir=#{openssl_path}",
+      'LDFLAGS' => "-L#{openssl_path}/lib",
+      'CPPFLAGS' => "-I#{openssl_path}/include"
     })
   end
 

--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -15,6 +15,7 @@ default[:passenger][:production][:status_server] = true
 
 default[:passenger][:production][:user] = node.fetch(:identity_shared_attributes).fetch(:production_user)
 default[:passenger][:production][:version] = '6.0.6'
+default[:passenger][:production][:nginx][:version] = '1.18.0'
 
 # Allow our local /16 to proxy setting X-Forwarded-For
 # This is a little broad, but because we expect security group rules to prevent

--- a/passenger/files/default/fipsmode.patch
+++ b/passenger/files/default/fipsmode.patch
@@ -1,0 +1,11 @@
+--- nginx-1.18.0.orig/src/event/ngx_event_openssl.c	2020-04-21 14:09:01.000000000 +0000
++++ nginx-1.18.0/src/event/ngx_event_openssl.c	2020-10-14 23:31:36.050855091 +0000
+@@ -164,6 +164,8 @@
+ 
+ #endif
+ 
++    FIPS_mode_set(1);
++
+ #ifndef SSL_OP_NO_COMPRESSION
+     {
+     /*


### PR DESCRIPTION
I tested this by applying it by hand.  I will investigate the build process and see if I can get an AMI out of this that I can try in my tspencer env, but for now, I thought I'd put this out for people to comment on.

We appear to be using a FIPS-certified module, but FIPS_mode has not been set.  This turns that on for nginx/passenger