### PR TITLE
Log passenger errors to a separate file

### DIFF
--- a/passenger/metadata.json
+++ b/passenger/metadata.json
@@ -5,29 +5,21 @@
   "maintainer": "James Harton, Sociable Limited.",
   "maintainer_email": "james@sociable.co.nz",
   "license": "MIT",
-  "platforms": {
-  },
+  "platforms": {},
   "dependencies": {
     "identity_shared_attributes": ">= 0.0.1"
   },
-  "recommendations": {
-  },
-  "suggestions": {
-  },
-  "conflicting": {
-  },
-  "providing": {
-  },
-  "replacing": {
-  },
-  "attributes": {
-  },
-  "groupings": {
-  },
+  "recommendations": {},
+  "suggestions": {},
+  "conflicting": {},
+  "providing": {},
+  "replacing": {},
+  "attributes": {},
+  "groupings": {},
   "recipes": {
     "passenger::install": "Install the passenger gem",
     "passenger::daemon": "Install passenger/nginx as a service.",
     "passenger::standalone": "Install passenger/nginx and start it as standalone."
   },
-  "version": "0.0.9"
+  "version": "0.0.10"
 }

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -9,17 +9,19 @@ events {
 include conf.d/*.conf;
 
 http {
-  passenger_min_instances <%= @passenger[:min_instances] %>;
-  passenger_max_instances_per_app <%= @passenger[:max_instances_per_app] %>;
-  passenger_max_pool_size <%= @passenger[:max_pool_size] %>;
-  passenger_pool_idle_time <%= @passenger[:pool_idle_time] %>;
-  passenger_root <%= @passenger_root %>;
-  passenger_ruby <%= @ruby_path %>;
-  passenger_show_version_in_header off;
-  passenger_user <%= @passenger_user %>;
+  # passenger config
+  passenger_log_file                <%= "#{@log_path}/passenger.log" %>%;
+  passenger_max_instances_per_app   <%= @passenger[:max_instances_per_app] %>;
+  passenger_max_pool_size           <%= @passenger[:max_pool_size] %>;
+  passenger_min_instances           <%= @passenger[:min_instances] %>;
+  passenger_pool_idle_time          <%= @passenger[:pool_idle_time] %>;
 <% @passenger[:pre_start].each do |url| %>
-  passenger_pre_start <%= url %>;
+  passenger_pre_start               <%= url %>;
 <% end %>
+  passenger_root                    <%= @passenger_root %>;
+  passenger_ruby                    <%= @ruby_path %>;
+  passenger_show_version_in_header  off;
+  passenger_user                    <%= @passenger_user %>;
 
   include mime.types;
   default_type application/octet-stream;


### PR DESCRIPTION
By default Passenger log messages are written to the Nginx global error log: https://www.phusionpassenger.com/library/config/nginx/reference/#passenger_log_file. This change has passenger log to a separate file for its events. This will make it easier to parse log events and debug issues with our stack.

Note, this also refactors the config block so its alphabetized and is spaced in a more human friendly fashion similar to terraform.