### PR TITLE
adjust OSSEC alerting

### DIFF
--- a/identity_ossec/files/default/syslog_rules.xml
+++ b/identity_ossec/files/default/syslog_rules.xml
@@ -363,10 +363,12 @@
     <description>Ignoring hpiod for producing useless logs.</description>
   </rule>
 
+<!-- Rule disabled until we can get operational alerting going on cgroup OOM killer events
   <rule id="5201" level="0">
     <pcre2>Memory cgroup out of memory</pcre2>
     <description>Ignoring cgroup OOM killer because it is not a security issue.</description>
   </rule>
+ -->
 </group> <!-- SYSLOG,LINUXKERNEL -->
 
 


### PR DESCRIPTION
roll back alerting on cgroup OOM killer until we can get an operational alert going