### PR TITLE
Set nofile limit to 2x the # of worker connections

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -50,3 +50,4 @@ default[:passenger][:production][:tcp_nopush] = false
 # http://nginx.org/en/docs/ngx_core_module.html#worker_processes
 default[:passenger][:production][:worker_processes] = node.fetch('cpu').fetch('total')
 default[:passenger][:production][:worker_connections] = 1024
+default[:passenger][:production][:nofile_limit] =  node.fetch('passenger').fetch('production').fetch('worker_connections') * 2

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -1,5 +1,6 @@
 #user  nobody;
 worker_processes  <%= @passenger[:worker_processes] %>;
+worker_rlimit_nofile <%= @passenger[:nofile_limit] %>;
 pid <%= @pidfile %>;
 
 events {
@@ -10,11 +11,13 @@ include conf.d/*.conf;
 
 http {
   # passenger config
-  passenger_log_file                <%= "#{@log_path}/passenger.log" %>%;
-  passenger_max_instances_per_app   <%= @passenger[:max_instances_per_app] %>;
-  passenger_max_pool_size           <%= @passenger[:max_pool_size] %>;
-  passenger_min_instances           <%= @passenger[:min_instances] %>;
-  passenger_pool_idle_time          <%= @passenger[:pool_idle_time] %>;
+  passenger_log_file                    <%= "#{@log_path}/passenger.log" %>%;
+  passenger_max_instances_per_app       <%= @passenger[:max_instances_per_app] %>;
+  passenger_max_pool_size               <%= @passenger[:max_pool_size] %>;
+  passenger_min_instances               <%= @passenger[:min_instances] %>;
+  passenger_pool_idle_time              <%= @passenger[:pool_idle_time] %>;
+  passenger_core_file_descriptor_ulimit <%= @passenger[:nofile_limit] %>;
+
 <% @passenger[:pre_start].each do |url| %>
   passenger_pre_start               <%= url %>;
 <% end %>


### PR DESCRIPTION
This adds config that increases the nofile limit (https://wiki.archlinux.org/index.php/Limits.conf#nofile) for the passenger (rails) and nginx worker process (anything not handled by rails) in support of https://github.com/18F/identity-devops/issues/3152. The value of 2x the worker connections was chosen since each worker connection, in general, needs two open files in order to function correctly. 

I tested by creating a new base image using this PR's SHA for the cookbooks:
```
    amazon-ebs:     +worker_rlimit_nofile 2048;
    amazon-ebs:     +pid /var/run/nginx.pid;
    amazon-ebs:
    amazon-ebs:     -#error_log  logs/error.log;
    amazon-ebs:     -#error_log  logs/error.log  notice;
    amazon-ebs:     -#error_log  logs/error.log  info;
    amazon-ebs:     -
    amazon-ebs:     -#pid        logs/nginx.pid;
    amazon-ebs:     -
    amazon-ebs:     -
    amazon-ebs:      events {
    amazon-ebs:     -    worker_connections  1024;
    amazon-ebs:     +  worker_connections  1024;
    amazon-ebs:      }
    amazon-ebs:
    amazon-ebs:     +include conf.d/*.conf;
    amazon-ebs:
    amazon-ebs:      http {
    amazon-ebs:     -    passenger_root /opt/ruby_build/builds/2.6.6/lib/ruby/gems/2.6.0/gems/passenger-6.0.6;
    amazon-ebs:     -    passenger_ruby /opt/ruby_build/builds/2.6.6/bin/ruby;
    amazon-ebs:     +  # passenger config
    amazon-ebs:     +  passenger_log_file                    /var/log/nginx/passenger.log%;
    amazon-ebs:     +  passenger_max_instances_per_app       0;
    amazon-ebs:     +  passenger_max_pool_size               8;
    amazon-ebs:     +  passenger_min_instances               8;
    amazon-ebs:     +  passenger_pool_idle_time              0;
    amazon-ebs:     +  passenger_core_file_descriptor_ulimit 2048;
```

With these changes on the app host you can see the new limit being set:

```
root@app-i-03783f.pt:/opt/nginx/conf# systemctl status passenger.service 
● passenger.service - LSB: Nginx/Passenger
   Loaded: loaded (/etc/init.d/passenger; generated)
   Active: active (running) since Mon 2021-01-25 21:30:16 UTC; 8s ago
     Docs: man:systemd-sysv-generator(8)
  Process: 2149 ExecStop=/etc/init.d/passenger stop (code=exited, status=0/SUCCESS)
  Process: 2487 ExecStart=/etc/init.d/passenger start (code=exited, status=0/SUCCESS)
    Tasks: 226 (limit: 4915)
   CGroup: /system.slice/passenger.service
           ├─2495 Passenger watchdog
           ├─2498 Passenger core
           ├─2517 nginx: master process /opt/nginx/sbin/nginx
           ├─2541 nginx: worker process
            ...
           ├─2569 Passenger AppPreloader: /srv/sp-oidc-sinatra/current
           ├─2664 Passenger AppPreloader: /srv/sp-oidc-sinatra/current (forking...)
            ...

root@app-i-03783f.pt:/opt/nginx/conf# cat /proc/2664/limits | grep -i files
Max open files            2048                 2048                 files     
root@app-i-03783f.pt:/opt/nginx/conf# cat /proc/2541/limits | grep -i files
Max open files            2048                 2048                 files 
```

I'm still trying to verify if this fixes the original issue in https://github.com/18F/identity-devops/issues/3152. My concern is that the http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile is setting a global value for all worker procs and is not per. worker proc as this PR intends. If it's global then we'll need to adjust this so it factors in CPU count:
```
nofile_limit = node.fetch('cpu').fetch('total') * node.fetch('passenger').fetch('production').fetch('worker_connections') * 2
default[:passenger][:production][:nofile_limit] = nofile_limit
```

I don't see that as any reason to hold up this PR on that testing, this doubles the current OS limit of 512 connections and better tunes it with our worker_connections value of 1024.