### PR TITLE
Change NGINX access.log to JSON line structured format

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -9,6 +9,9 @@ default[:passenger][:production][:native_support_dir] = node.fetch(:passenger).f
 
 default[:passenger][:production][:configure_flags] = "--with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-ld-opt=\"-L#{openssl_installed_path}/lib\" --with-cc-opt=\"-I#{openssl_installed_path}/include\""
 default[:passenger][:production][:log_path] = '/var/log/nginx'
+# Relevant for any NGINX instance behind an ALB
+default[:passenger][:production][:log_alb_headers] = true
+# Relevant only when client certificates are passed directly to NGINX
 default[:passenger][:production][:log_client_ssl] = false
 
 # Enable the status server on 127.0.0.1

--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -9,6 +9,7 @@ default[:passenger][:production][:native_support_dir] = node.fetch(:passenger).f
 
 default[:passenger][:production][:configure_flags] = "--with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-ld-opt=\"-L#{openssl_installed_path}/lib\" --with-cc-opt=\"-I#{openssl_installed_path}/include\""
 default[:passenger][:production][:log_path] = '/var/log/nginx'
+default[:passenger][:production][:log_client_ssl] = false
 
 # Enable the status server on 127.0.0.1
 default[:passenger][:production][:status_server] = true

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -91,7 +91,6 @@ http {
         '"dest_ip": "$server_addr", '
         '"src": "$remote_addr", '
         '"src_ip": "$realip_remote_addr", '
-        '"lb_if_proxied": "$lb_if_proxied", '
         '"user": "$remote_user", '
         '"protocol": "$server_protocol", '
         '"http_method": "$request_method", '
@@ -101,9 +100,11 @@ http {
         '"http_referer": "$http_referer", '
         '"http_user_agent": "$http_user_agent", '
         '"nginx_version": "$nginx_version", '
+<% if @passenger.fetch(:log_alb_headers) %>
+        '"lb_if_proxied": "$lb_if_proxied", '
         '"http_x_forwarded_for": "$http_x_forwarded_for", '
-        '"uri_path": "$uri", '
-        '"uri_query": "$query_string", '
+        '"http_x_amzn_trace_id": "$http_x_amzn_trace_id", '
+<% end %>
         '"response_time": "$upstream_response_time", '
         '"request_time": "$request_time", '
         '"request": "$request", '
@@ -111,7 +112,8 @@ http {
         '"ssl_client_serial": "$ssl_client_serial", '
         '"ssl_client_expire_days": "$ssl_client_v_remain", '
 <% end %>
-        '"http_x_amzn_trace_id": "$http_x_amzn_trace_id"'
+        '"uri_path": "$uri", '
+        '"uri_query": "$query_string"'
     '}';
 
   access_log <%= @log_path or raise "no @log_path" %>/access.log kv;

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -82,26 +82,39 @@ http {
     default $realip_remote_addr;
   }
 
-  # Specify a fancy human-friendly format for our access logs
-  log_format fancy '[$time_local] $host:$server_port : $remote_addr - ($lb_if_proxied) '
-                     '$remote_user "$request" $status "$status_reason" $body_bytes_sent Bytes '
-                     '"$http_referer" "$http_user_agent" $request_time sec "$http_x_amzn_trace_id"';
-
   # Specify a key=value format useful for machine parsing
-  log_format kv 'hostname="$host" dest_port="$server_port" dest_ip="$server_addr" '
-                  'src="$remote_addr" src_ip="$realip_remote_addr" lb_if_proxied="$lb_if_proxied" '
-                  'user="$remote_user" time_local="$time_local" protocol="$server_protocol" '
-                  'status="$status" bytes_out="$body_bytes_sent" '
-                  'bytes_in="$upstream_response_length" http_referer="$http_referer" '
-                  'http_user_agent="$http_user_agent" nginx_version="$nginx_version" '
-                  'http_x_forwarded_for="$http_x_forwarded_for" uri_query="$query_string" '
-                  'uri_path="$uri" http_method="$request_method" '
-                  'response_time="$upstream_response_time" '
-                  'request_time="$request_time" request="$request" '
-                  'http_x_amzn_trace_id="http_x_amzn_trace_id"';
+  log_format kv escape=json
+    '{'
+        '"hostname": "$host", '
+        '"dest_port": "$server_port", '
+        '"dest_ip": "$server_addr", '
+        '"src": "$remote_addr", '
+        '"src_ip": "$realip_remote_addr", '
+        '"lb_if_proxied": "$lb_if_proxied", '
+        '"user": "$remote_user", '
+        '"time_local": "$time_local", '
+        '"protocol": "$server_protocol", '
+        '"http_method": "$request_method", '
+        '"status": "$status", '
+        '"bytes_out": "$body_bytes_sent", '
+        '"bytes_in": "$upstream_response_length", '
+        '"http_referer": "$http_referer", '
+        '"http_user_agent": "$http_user_agent", '
+        '"nginx_version": "$nginx_version", '
+        '"http_x_forwarded_for": "$http_x_forwarded_for", '
+        '"uri_path": "$uri", '
+        '"uri_query": "$query_string", '
+        '"response_time": "$upstream_response_time", '
+        '"request_time": "$request_time", '
+        '"request": "$request", '
+<% if @passenger.fetch(:log_client_ssl) %>
+        '"ssl_client_serial": "$ssl_client_serial", '
+        '"ssl_client_expire_days": "$ssl_client_v_remain", ';
+<% end %>
+        '"http_x_amzn_trace_id": "$http_x_amzn_trace_id"'
+    '}';
 
   access_log <%= @log_path or raise "no @log_path" %>/access.log kv;
-  access_log <%= @log_path or raise "no @log_path" %>/fancy_access.log fancy;
   error_log  <%= @log_path or raise "no @log_path" %>/error.log info;
 
   # Get $status_reason variable, a human readable version of $status

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -109,6 +109,8 @@ http {
         '"request_time": "$request_time", '
         '"request": "$request", '
 <% if @passenger.fetch(:log_client_ssl) %>
+        '"ssl_client_fingerprint": "$ssl_client_fingerprint", '
+        '"ssl_client_issuer_dn": "$ssl_client_i_dn", '
         '"ssl_client_serial": "$ssl_client_serial", '
         '"ssl_client_expire_days": "$ssl_client_v_remain", '
 <% end %>

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -85,6 +85,7 @@ http {
   # Specify a key=value format useful for machine parsing
   log_format kv escape=json
     '{'
+        '"time": "$time_local", '
         '"hostname": "$host", '
         '"dest_port": "$server_port", '
         '"dest_ip": "$server_addr", '
@@ -92,7 +93,6 @@ http {
         '"src_ip": "$realip_remote_addr", '
         '"lb_if_proxied": "$lb_if_proxied", '
         '"user": "$remote_user", '
-        '"time_local": "$time_local", '
         '"protocol": "$server_protocol", '
         '"http_method": "$request_method", '
         '"status": "$status", '
@@ -109,7 +109,7 @@ http {
         '"request": "$request", '
 <% if @passenger.fetch(:log_client_ssl) %>
         '"ssl_client_serial": "$ssl_client_serial", '
-        '"ssl_client_expire_days": "$ssl_client_v_remain", ';
+        '"ssl_client_expire_days": "$ssl_client_v_remain", '
 <% end %>
         '"http_x_amzn_trace_id": "$http_x_amzn_trace_id"'
     '}';


### PR DESCRIPTION
Addresses https://github.com/18F/identity-devops/issues/3543

* Changes `/var/log/nginx/access.log` to JSON line format
* Adds flag to disable ALB relevant headers for NLB/ELB TCP load balancers
* Adds flag to add SSL client certificate attributes for PIVCAC use
* Removes unused fancy log

Example snippet of `/opt/nginx/conf/nginx.conf`:
~~~
  log_format kv escape=json
    '{'
        '"time": "$time_local", '
        '"hostname": "$host", '
        '"dest_port": "$server_port", '
        '"dest_ip": "$server_addr", '
        '"src": "$remote_addr", '
        '"src_ip": "$realip_remote_addr", '
        '"user": "$remote_user", '
        '"protocol": "$server_protocol", '
        '"http_method": "$request_method", '
        '"status": "$status", '
        '"bytes_out": "$body_bytes_sent", '
        '"bytes_in": "$upstream_response_length", '
        '"http_referer": "$http_referer", '
        '"http_user_agent": "$http_user_agent", '
        '"nginx_version": "$nginx_version", '
        '"lb_if_proxied": "$lb_if_proxied", '
        '"http_x_forwarded_for": "$http_x_forwarded_for", '
        '"http_x_amzn_trace_id": "$http_x_amzn_trace_id", '
        '"response_time": "$upstream_response_time", '
        '"request_time": "$request_time", '
        '"request": "$request", '
        '"uri_path": "$uri", '
        '"uri_query": "$query_string"'
    '}';

  access_log /var/log/nginx/access.log kv;
~~~

Example lines from `idp`:
~~~
{"time": "07/Jun/2021:13:14:53 +0000", "hostname": "idp.pauldoom.identitysandbox.gov", "dest_port": "443", "dest_ip": "172.16.33.140", "src": "2601:449:8200:6128:e5cb:dfa:6e22:9b64", "src_ip": "172.16.33.251", "user": "", "protocol": "HTTP/1.1", "http_method": "GET", "status": "200", "bytes_out": "170", "bytes_in": "", "http_referer": "https://idp.pauldoom.identitysandbox.gov/", "http_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36", "nginx_version": "1.18.0", "lb_if_proxied": "172.16.33.251", "http_x_forwarded_for": "2601:449:8200:6128:e5cb:dfa:6e22:9b64", "http_x_amzn_trace_id": "Root=1-60be1bcd-328afb623b56a40a038c122c", "response_time": "", "request_time": "0.000", "request": "GET /manifest.json HTTP/1.1", "uri_path": "/manifest.json", "uri_query": ""}
~~~