### PR TITLE
Upgrade NGINX to 1.20.1 and Passenger to 6.0.9

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -18,8 +18,8 @@ default[:passenger][:production][:log_client_ssl] = false
 default[:passenger][:production][:status_server] = true
 
 default[:passenger][:production][:user] = node.fetch(:identity_shared_attributes).fetch(:production_user)
-default[:passenger][:production][:version] = '6.0.6'
-default[:passenger][:production][:nginx][:version] = '1.18.0'
+default[:passenger][:production][:version] = '6.0.9'
+default[:passenger][:production][:nginx][:version] = '1.20.1'
 
 # Allow our local /16 to proxy setting X-Forwarded-For
 # This is a little broad, but because we expect security group rules to prevent


### PR DESCRIPTION
Addresses https://github.com/18F/identity-security-private/issues/2400

NGINX 1.20.1 - Fixes CVE-2021-23017
Passenger 6.0.9 - Aligns with NGINX 1.20.1