### PR TITLE
remove Bundler 1.x.x install from identity_ruby/cookbooks/base-image

### DIFF
--- a/identity_ruby/recipes/default.rb
+++ b/identity_ruby/recipes/default.rb
@@ -49,17 +49,6 @@ node.fetch('identity_ruby').fetch('ruby_versions').each do |version|
       'RBENV_VERSION' => version
     })
   end
-
-  # Backwards compatibility for bundler 1.x
-  # This can be removed once all login.gov apps are using Bundler 2.0
-  # Install bundler 1.x in addition to whatever comes with rbenv
-  execute "install bundler 1.x for rbenv #{version}" do
-    command %w[rbenv exec gem install bundler -v] + ['~> 1.17']
-    environment({
-      'RBENV_ROOT' => rbenv_root,
-      'RBENV_VERSION' => version
-    })
-  end
 end
 
 # set default rbenv ruby version if provided


### PR DESCRIPTION
Does what it says on the tin. (Helpfully, stops installing Bundler 1.x.x for _all_ versions of Ruby installed in the base image.)

Addresses https://github.com/18F/identity-devops/issues/3563