### PR TITLE
removing snapd restart from identity_base_config::ruby

### DIFF
--- a/identity_base_config/recipes/ruby.rb
+++ b/identity_base_config/recipes/ruby.rb
@@ -53,12 +53,6 @@ file '/etc/environment' do
     header + global_env_vars.map { |key, val| "#{key}='#{val}'" }.join("\n") \
     + "\n"
   )
-  notifies :run, 'execute[restart_snapd]'
-end
-
-execute 'restart_snapd' do
-  command 'systemctl restart snapd'
-  action :nothing
 end
 
 # install dependencies


### PR DESCRIPTION
This particular execution block is failing -- notably, on `pivcac` and `worker` instances.

```
---- Begin output of systemctl restart snapd ----
STDOUT: 
STDERR: Job for snapd.service canceled.
---- End output of systemctl restart snapd ----
Ran systemctl restart snapd returned 1
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
provision.sh: ERROR -- exiting after failure
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

While a root cause hasn't yet been determined -- likely another issue with the upstream Ubuntu Pro images -- this block is actually no longer needed, so it can be removed to prevent the above crash from happening.