### PR TITLE
Remove Citadel

### DIFF
--- a/config_loader/Berksfile
+++ b/config_loader/Berksfile
@@ -2,17 +2,4 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-# We have to reference this special citadel-build repository for two reasons:
-#
-# 1. We have a custom fork of https://github.com/poise/citadel at
-#    https://github.com/18f/citadel.git because of
-#    https://github.com/poise/citadel/pull/35 and
-#    https://github.com/poise/citadel/pull/36.
-# 2. There is an extra build step required, and the citadel repository itself is
-#    a valid cookbook.  See the citadel-build repository for more details.  This
-#    worked before without this extra repo because we were pulling the built
-#    citadel from https://supermarket.chef.io.
-#
-# Once the pull requests are merged and a new citadel version is released we can
-# get rid of this.
-cookbook 'citadel_fork', '~> 9.2.0', git: 'https://github.com/18f/citadel-build.git'
+cookbook 'aws_metadata', path: "../aws_metadata"

--- a/config_loader/attributes/default.rb
+++ b/config_loader/attributes/default.rb
@@ -1,3 +1,1 @@
 default['config_loader']['bucket_prefix'] = nil
-default['citadel']['region'] = Chef::Recipe::AwsMetadata.get_aws_region
-default['citadel']['bucket'] = "#{node['config_loader']['bucket_prefix']}.#{Chef::Recipe::AwsMetadata.get_aws_account_id}-#{Chef::Recipe::AwsMetadata.get_aws_region}"

--- a/config_loader/libraries/config_helper.rb
+++ b/config_loader/libraries/config_helper.rb
@@ -2,19 +2,33 @@ require 'json'
 
 class Chef::Recipe::ConfigLoader
   def self.load_config(node, key, common: false)
-    citadel = Citadel.new(node)
+    url = "s3://#{node['login_dot_gov']['secrets_bucket']}"
     prefix = common ? "common" : node.chef_environment
-    citadel[File.join(prefix, key)]
+    url = "#{url}/#{prefix}/#{key}"
+    result = `aws s3 cp #{url} -`.chomp
+    if $?.success?
+      result
+    else
+      raise result
+    end
+  rescue StandardError => err
+    if (err.message =~ /An error occurred \(404\)/ &&
+        node.chef_environment != "prod")
+      Chef::Log.warn(err.message) if print_warnings
+      return nil
+    else
+      raise
+    end
   end
 
-  # Like load_config, but return nil with a warning if Citadel receives an HTTP
+  # Like load_config, but return nil with a warning if s3 receives an HTTP
   # 404 response code. This only applies to cases where node.chef_environment
   # is not "prod". In the "prod" environment, always raise on errors and never
   # return nil.
   def self.load_config_or_nil(node, key, print_warnings: true)
-    load_config(node, key)
-  rescue Citadel::CitadelError => err
-    if (err.message =~ /Unable to download .*: 404 "Not Found"/ &&
+    raw = load_config(node, key)
+  rescue err
+    if (err.message =~ /An error occurred \(404\)/ &&
         node.chef_environment != "prod")
       Chef::Log.warn(err.message) if print_warnings
       return nil
@@ -24,11 +38,16 @@ class Chef::Recipe::ConfigLoader
   end
 
   # Like load_config, but designed to handle nested secrets data. If the
-  # contents are being loaded from citadel, also JSON.parse the data.
+  # contents are being loaded, also JSON.parse the data.
   def self.load_json(node, key, common: false)
-    citadel = Citadel.new(node)
+    url = "s3://#{node['login_dot_gov']['secrets_bucket']}"
     prefix = common ? "common" : node.chef_environment
-    raw = citadel[File.join(prefix, key)]
-    JSON.parse(raw)
+    url = "#{url}/#{prefix}/#{key}"
+    raw = `aws s3 cp #{url} - 2>&1`.chomp
+    if $?.success?
+      JSON.parse(raw)
+    else
+      raise raw
+    end
   end
 end

--- a/config_loader/metadata.rb
+++ b/config_loader/metadata.rb
@@ -4,10 +4,9 @@ maintainer_email 'you@example.com'
 license 'All Rights Reserved'
 description 'Installs/Configures config_loader'
 long_description 'Installs/Configures config_loader'
-version '0.2.2'
+version '0.3.0'
 chef_version '>= 12.15.19' if respond_to?(:chef_version)
 
 # both of these dependencies must also be within the top-level Berksfile
 # for this cookbook to operate correctly
-depends 'citadel_fork'
 depends 'aws_metadata'


### PR DESCRIPTION
Citadel is unmaintained and our use of it is limited to copying files from S3, which we can do ourselves and reduce the amount of code we depend on

I tested this in my sandbox, and files seem to be copied correctly