### PR TITLE
do not chomp newline off prematurely in config_loader

### DIFF
--- a/config_loader/libraries/config_helper.rb
+++ b/config_loader/libraries/config_helper.rb
@@ -5,7 +5,7 @@ class Chef::Recipe::ConfigLoader
     url = "s3://#{node['login_dot_gov']['secrets_bucket']}"
     prefix = common ? "common" : node.chef_environment
     url = "#{url}/#{prefix}/#{key}"
-    result = `aws s3 cp #{url} - 2>&1`.chomp
+    result = `aws s3 cp #{url} - 2>&1`
     if $?.success?
       result
     else


### PR DESCRIPTION
I thought the shell call was adding a new line, so I called chomp, but the shell call does not, I was just testing with files that have a new line at the end.