### PR TITLE
specify bundler version via identity_ruby attribute

### DIFF
--- a/identity_ruby/attributes/default.rb
+++ b/identity_ruby/attributes/default.rb
@@ -2,6 +2,7 @@
 # The caller is expected to set RBENV_ROOT to this path in /etc/environment to
 # set it globally and to add $RBENV_ROOT/shims/ to the global PATH.
 default['identity_ruby']['rbenv_root'] = '/opt/ruby_build'
+default['identity_ruby']['bundler_version'] = nil
 
 # Array of which ruby versions to install
 default['identity_ruby']['ruby_versions'] = []

--- a/identity_ruby/recipes/default.rb
+++ b/identity_ruby/recipes/default.rb
@@ -9,6 +9,9 @@ ENV['RBENV_ROOT'] = rbenv_root
 # install rbenv version from apt
 package 'rbenv'
 
+# specify bundler version
+bundler_version = node.fetch('identity_ruby').fetch('bundler_version')
+
 #install ruby-build
 execute 'install ruby-build' do
   command 'git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build'
@@ -29,9 +32,9 @@ node.fetch('identity_ruby').fetch('ruby_versions').each do |version|
     end
   end
 
-  #install current version of bundler 2.0
-  execute "install current bundler for rbenv #{version}" do
-    command %w[rbenv exec gem install bundler]
+  #install bundler_version of bundler
+  execute "install bundler #{bundler_version} for rbenv #{version}" do
+    command "rbenv exec gem install bundler:#{bundler_version}"
     environment({
       'RBENV_ROOT' => rbenv_root,
       'RBENV_VERSION' => version

--- a/identity_shared_attributes/attributes/default.rb
+++ b/identity_shared_attributes/attributes/default.rb
@@ -8,10 +8,10 @@ def read_env_file(filename)
   end
 end
 
-default[:identity_shared_attributes][:cache_dir] = '/var/cache/chef'
+default[:identity_shared_attributes][:cache_dir]       = '/var/cache/chef'
 default[:identity_shared_attributes][:openssl_version] = '1.1.1'
 default[:identity_shared_attributes][:production_user] = 'websrv'
-default[:identity_shared_attributes][:system_user] = 'appinstall'
-default[:identity_shared_attributes][:proxy_server] = read_env_file('/etc/login.gov/info/proxy_server')
-default[:identity_shared_attributes][:proxy_port] = read_env_file('/etc/login.gov/info/proxy_port')
-default[:identity_shared_attributes][:rbenv_root] = '/opt/ruby_build'
+default[:identity_shared_attributes][:system_user]     = 'appinstall'
+default[:identity_shared_attributes][:proxy_server]    = read_env_file('/etc/login.gov/info/proxy_server')
+default[:identity_shared_attributes][:proxy_port]      = read_env_file('/etc/login.gov/info/proxy_port')
+default[:identity_shared_attributes][:rbenv_root]      = '/opt/ruby_build'


### PR DESCRIPTION
The `identity_ruby` recipe currently grabs the most recent version of Bundler when `gem install bundler` is run. At the moment, [said most-recent-version (2.3.12) has an open bug related to the `required_rubygems_version` field](https://github.com/rubygems/rubygems/issues/5492), causing most/all `bundle install` operations with v2.3.12 to fail with `undefined method 'none?' for nil:NilClass` errors.

This PR updates the `identity_ruby` recipe so that the version of Bundler can be specified via the `default['identity_ruby']['bundler_version']` attribute, which we can pass in via another cookbook/recipe that calls it (hence defaulting to `nil` by default here).