### PR TITLE
remove pip-whl before doing a python3-pip install

### DIFF
--- a/static_eip/resources/assign.rb
+++ b/static_eip/resources/assign.rb
@@ -12,6 +12,7 @@ action :create do
   package 'awscli'
   package 'python'
   package 'python-netaddr'
+  execute 'apt-get -q -y remove python-pip-whl'
   package 'python3-pip'
   execute 'pip3 install aws-ec2-assign-elastic-ip'
 


### PR DESCRIPTION
Occasionally, the baked-into-the-AMI package of `python-pip-whl` will be out of date and/or requiring a specific hard-coded version. As a result, `python3-pip` -- which has `python-pip-whl` as a dependency -- will fail to install:

```
STDOUT: Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation: 
The following packages have unmet dependencies:
python3-pip : Depends: python-pip-whl (= 9.0.1-2.3~ubuntu1.18.04.5) but 9.0.1-2.3~ubuntu1.18.04.5+esm2 is to be installed
Recommends: python3-dev (>= 3.2) but it is not going to be installed
Recommends: python3-setuptools but it is not going to be installed
Recommends: python3-wheel but it is not going to be installed
STDERR: E: Unable to correct problems, you have held broken packages.
Ran ["apt-get", "-q", "-y", "--allow-downgrades", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold", "install", "python3-pip=9.0.1-2.3~ubuntu1.18.04.5"] returned 100
```

[A common suggestion](https://askubuntu.com/a/1106541) is to simply remove the old `python-pip-whl`, causing `python3-pip` to get the latest and greatest versions of its dependencies vs. the locked/broken one(s).

While a more elegant solution should be implemented in the future, the one in this PR does work like a charm.