### PR TITLE
Sshelton/ubuntu upgrade 4735

### DIFF
--- a/identity_base_config/recipes/default.rb
+++ b/identity_base_config/recipes/default.rb
@@ -4,8 +4,10 @@
 #
 # Common packages and config used by all hosts
 
+package 'python3-pip'
+
 execute 'install awscli as needed' do
-  command 'pip install awscli'
+  command 'pip3 install awscli'
   not_if { File.exist?('/usr/local/bin/aws') }
 end
 

--- a/identity_ntp/recipes/default.rb
+++ b/identity_ntp/recipes/default.rb
@@ -5,7 +5,7 @@ end
 # Assert that we're on an expected OS release
 release = node.fetch('lsb').fetch('release')
 case release
-when '18.04'
+when '18.04', '20.04'
   # OK
 else
   raise NotImplementedError.new("Unexpected OS release: #{release.inspect}")

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -118,8 +118,6 @@ cookbook_file "#{nginx_path}/conf/status-map.conf" do
   mode "0644"
 end
 
-# Grab Cloudfront IP CIDR list, cleanup data to get the CIDRS we want
-
 extend Chef::Mixin::ShellOut
 
 aws_ip_ranges_url = "https://ip-ranges.amazonaws.com/ip-ranges.json"

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -11,7 +11,7 @@ case node[:platform_version]
 when '16.04'
   package 'libcurl4-openssl-dev'
   package 'libpcre3-dev'
-when '18.04'
+when '18.04', '20.04'
   package 'libcurl4-gnutls-dev'
 end
 

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -118,6 +118,8 @@ cookbook_file "#{nginx_path}/conf/status-map.conf" do
   mode "0644"
 end
 
+# Grab Cloudfront IP CIDR list, cleanup data to get the CIDRS we want
+
 extend Chef::Mixin::ShellOut
 
 aws_ip_ranges_url = "https://ip-ranges.amazonaws.com/ip-ranges.json"

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -11,7 +11,12 @@ case node[:platform_version]
 when '16.04'
   package 'libcurl4-openssl-dev'
   package 'libpcre3-dev'
-when '18.04', '20.04'
+when '18.04'
+  package 'libcurl4-gnutls-dev'
+# Needs libpcre3 installed otherwise nginx compiles --without-http_rewrite_module
+when '20.04'
+  package 'libpcre3'
+  package 'libpcre3-dev'
   package 'libcurl4-gnutls-dev'
 end
 


### PR DESCRIPTION
Tracking PR as part of the [Ubuntu 20.04 Upgrade](https://github.com/18F/identity-devops/issues/4375) this PR updates two cookbooks to allow for Ubuntu 20.04 support, needs the libpcre3 libraries otherwise nginx compiles with the --without-http_rewrite_module which breaks things like returns.