### PR TITLE
Update Passenger cookbook to add Cloudfront CIDRs for better client ip preservation

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -19,11 +19,14 @@ default[:passenger][:production][:version] = '6.0.14'
 default[:passenger][:production][:nginx][:version] = '1.22.0'
 
 # Allow our local /16 to proxy setting X-Forwarded-For
-# This is a little broad, but because we expect security group rules to prevent
-# anyone except our trusted ALB from connecting anyway, we don't really care
+# This is a little broad, but because we expect security group rules and
+# Cloudfronts Origin-Access-Control header to prevent anyone except our
+# trusted ALB/Cloudfront from connecting anyway, we don't really care
 # who is able to set X-Forwarded-For headers.
 #default[:passenger][:production][:realip_from_cidr] = node.fetch(:cloud).fetch('local_ipv4').split('.')[0..1].join('.') + '.0.0/16'
 default[:passenger][:production][:realip_from_cidr] = '172.16.0.0/16'
+# Adds Cloudfront CIDRS to the set_real_ip_from to allow for proper client ip preservation
+default[:passenger][:production][:enable_cloudfront_support] = true
 
 # Tune the following configurations for your environment. For more info see:
 # https://www.phusionpassenger.com/library/config/nginx/optimization

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -112,6 +112,8 @@ cookbook_file "#{nginx_path}/conf/status-map.conf" do
   mode "0644"
 end
 
+# Grab Cloudfront IP CIDR list, cleanup data to get the CIDRS we want
+
 extend Chef::Mixin::ShellOut
 
 template "#{nginx_path}/conf/nginx.conf" do
@@ -126,7 +128,11 @@ template "#{nginx_path}/conf/nginx.conf" do
     ruby_path: node.fetch(:identity_shared_attributes).fetch(:rbenv_root) + '/shims/ruby',
     :passenger => node[:passenger][:production],
     :pidfile => "/var/run/nginx.pid",
-    :passenger_user => node[:passenger][:production][:user]
+    :passenger_user => node[:passenger][:production][:user],
+    cloudfront_cidrs: lazy {
+      # Grab Cloudfront IP CIDR list, cleanup data to get the CIDRS we want, convert to array to iterate over
+      shell_out("curl https://d7uri8nf7uskq.cloudfront.net/tools/list-cloudfront-ips | tr -d '[]{}\" a-z A-Z _:'").stdout.split(',')
+    }
   )
 end
 

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -59,6 +59,16 @@ http {
   # Enable XSS filter
   add_header X-XSS-Protection "1; mode=block";
 
+<% if @passenger.fetch(:enable_cloudfront_support) %>
+  # Enables nginx to check multiple set_real_ip_from lines 
+  real_ip_recursive on;
+  # Add Cloudfront CIDRS to trusted CIDR range for real ip computation
+  <% @cloudfront_cidrs.each do |cidr| %>
+  set_real_ip_from <% cidr %>;
+  <% end %>
+<% end -%>
+   
+
   # Pull the real client's IP address out of X-Forwarded-For
   set_real_ip_from <%= @passenger.fetch(:realip_from_cidr) %>;
   real_ip_header X-Forwarded-For;

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -64,7 +64,7 @@ http {
   real_ip_recursive on;
   # Add Cloudfront CIDRS to trusted CIDR range for real ip computation
   <% @cloudfront_cidrs.each do |cidr| %>
-  set_real_ip_from <% cidr %>;
+  set_real_ip_from <%= cidr %>;
   <% end %>
 <% end -%>
    


### PR DESCRIPTION
Summary: Adds the ability to dynamically pull AWS's Cloudfront CIDR blocks and add them to the nginx.conf file to allow for proper client ip preservation. This happens by parsing AWS's provided Cloudfront CIDR list located [HERE](https://d7uri8nf7uskq.cloudfront.net/tools/list-cloudfront-ips) then lazy loading the output of the shell out into the ERB file to iterate over.

Addresses: https://github.com/18F/identity-devops/issues/4948

<details><summary><tt>Example nginx.conf from sandbox with new base images</tt></summary>

```
root@idp-i-050806.sshelton:~# cat /opt/nginx/conf/nginx.conf
#user  nobody;
worker_processes  8;
worker_rlimit_nofile 2048;
pid /var/run/nginx.pid;

events {
  worker_connections  1024;
}

include conf.d/*.conf;

http {
  # passenger config
  passenger_log_file                    /var/log/nginx/passenger.log;
  passenger_max_instances_per_app       0;
  passenger_max_pool_size               16;
  passenger_min_instances               16;
  passenger_pool_idle_time              0;
  passenger_core_file_descriptor_ulimit 2048;

  passenger_root                    /opt/ruby_build/versions/2.7.5/lib/ruby/gems/2.7.0/gems/passenger-6.0.14;
  passenger_ruby                    /opt/ruby_build/shims/ruby;
  passenger_show_version_in_header  off;
  passenger_user                    websrv;

  include mime.types;
  default_type application/octet-stream;

  sendfile on;
  tcp_nopush off;
  keepalive_timeout 60 50;
  gzip on;
  gzip_types text/plain text/css application/xml application/javascript application/json image/jpg image/jpeg image/png image/gif image/svg+xml font/woff2 woff2;

  # Timeouts definition
  client_body_timeout   10;
  client_header_timeout 10;
  send_timeout          10;
  # Set buffer size limits
  client_body_buffer_size  1k;
  client_header_buffer_size 1k;
  client_max_body_size 20k;
  large_client_header_buffers 2 20k;
  # Limit connections
  limit_conn addr       20;
  limit_conn_status     429;
  limit_conn_zone       $binary_remote_addr zone=addr:5m;
  # Disable sending server versions
  server_tokens off;
  # Prevent clickJacking attack
  add_header X-Frame-Options SAMEORIGIN;
  # Disable content-type sniffing
  add_header X-Content-Type-Options nosniff;
  # Enable XSS filter
  add_header X-XSS-Protection "1; mode=block";

  # Enables nginx to check multiple set_real_ip_from lines
  real_ip_recursive on;
  # Add Cloudfront CIDRS to trusted CIDR range for real ip computation
  set_real_ip_from 120.52.22.96/27;
  set_real_ip_from 205.251.249.0/24;
  set_real_ip_from 180.163.57.128/26;
  set_real_ip_from 204.246.168.0/22;
  set_real_ip_from 18.160.0.0/15;
  set_real_ip_from 205.251.252.0/23;
  set_real_ip_from 54.192.0.0/16;
  set_real_ip_from 204.246.173.0/24;
  set_real_ip_from 54.230.200.0/21;
  set_real_ip_from 120.253.240.192/26;
  set_real_ip_from 116.129.226.128/26;
  set_real_ip_from 130.176.0.0/17;
  set_real_ip_from 108.156.0.0/14;
  set_real_ip_from 99.86.0.0/16;
  set_real_ip_from 205.251.200.0/21;
  set_real_ip_from 223.71.71.128/25;
  set_real_ip_from 13.32.0.0/15;
  set_real_ip_from 120.253.245.128/26;
  set_real_ip_from 13.224.0.0/14;
  set_real_ip_from 70.132.0.0/18;
  set_real_ip_from 15.158.0.0/16;
  set_real_ip_from 13.249.0.0/16;
  set_real_ip_from 18.238.0.0/15;
  set_real_ip_from 18.244.0.0/15;
  set_real_ip_from 205.251.208.0/20;
  set_real_ip_from 65.9.128.0/18;
  set_real_ip_from 130.176.128.0/18;
  set_real_ip_from 58.254.138.0/25;
  set_real_ip_from 54.230.208.0/20;
  set_real_ip_from 116.129.226.0/25;
  set_real_ip_from 52.222.128.0/17;
  set_real_ip_from 18.164.0.0/15;
  set_real_ip_from 64.252.128.0/18;
  set_real_ip_from 205.251.254.0/24;
  set_real_ip_from 54.230.224.0/19;
  set_real_ip_from 71.152.0.0/17;
  set_real_ip_from 216.137.32.0/19;
  set_real_ip_from 204.246.172.0/24;
  set_real_ip_from 18.172.0.0/15;
  set_real_ip_from 120.52.39.128/27;
  set_real_ip_from 118.193.97.64/26;
  set_real_ip_from 223.71.71.96/27;
  set_real_ip_from 18.154.0.0/15;
  set_real_ip_from 54.240.128.0/18;
  set_real_ip_from 205.251.250.0/23;
  set_real_ip_from 180.163.57.0/25;
  set_real_ip_from 52.46.0.0/18;
  set_real_ip_from 223.71.11.0/27;
  set_real_ip_from 52.82.128.0/19;
  set_real_ip_from 54.230.0.0/17;
  set_real_ip_from 54.230.128.0/18;
  set_real_ip_from 54.239.128.0/18;
  set_real_ip_from 130.176.224.0/20;
  set_real_ip_from 36.103.232.128/26;
  set_real_ip_from 52.84.0.0/15;
  set_real_ip_from 143.204.0.0/16;
  set_real_ip_from 144.220.0.0/16;
  set_real_ip_from 120.52.153.192/26;
  set_real_ip_from 119.147.182.0/25;
  set_real_ip_from 120.232.236.0/25;
  set_real_ip_from 54.182.0.0/16;
  set_real_ip_from 58.254.138.128/26;
  set_real_ip_from 120.253.245.192/27;
  set_real_ip_from 54.239.192.0/19;
  set_real_ip_from 18.64.0.0/14;
  set_real_ip_from 120.52.12.64/26;
  set_real_ip_from 99.84.0.0/16;
  set_real_ip_from 130.176.192.0/19;
  set_real_ip_from 52.124.128.0/17;
  set_real_ip_from 204.246.164.0/22;
  set_real_ip_from 13.35.0.0/16;
  set_real_ip_from 204.246.174.0/23;
  set_real_ip_from 36.103.232.0/25;
  set_real_ip_from 119.147.182.128/26;
  set_real_ip_from 118.193.97.128/25;
  set_real_ip_from 120.232.236.128/26;
  set_real_ip_from 204.246.176.0/20;
  set_real_ip_from 65.8.0.0/16;
  set_real_ip_from 65.9.0.0/17;
  set_real_ip_from 108.138.0.0/15;
  set_real_ip_from 120.253.241.160/27;
  set_real_ip_from 64.252.64.0/18;
  set_real_ip_from 52.52.191.128/26;
  set_real_ip_from 13.113.196.64/26;
  set_real_ip_from 13.113.203.0/24;
  set_real_ip_from 52.199.127.192/26;
  set_real_ip_from 13.124.199.0/24;
  set_real_ip_from 3.35.130.128/25;
  set_real_ip_from 52.78.247.128/26;
  set_real_ip_from 13.233.177.192/26;
  set_real_ip_from 15.207.13.128/25;
  set_real_ip_from 15.207.213.128/25;
  set_real_ip_from 52.66.194.128/26;
  set_real_ip_from 13.228.69.0/24;
  set_real_ip_from 52.220.191.0/26;
  set_real_ip_from 13.210.67.128/26;
  set_real_ip_from 13.54.63.128/26;
  set_real_ip_from 99.79.169.0/24;
  set_real_ip_from 18.192.142.0/23;
  set_real_ip_from 35.158.136.0/24;
  set_real_ip_from 52.57.254.0/24;
  set_real_ip_from 13.48.32.0/24;
  set_real_ip_from 18.200.212.0/23;
  set_real_ip_from 52.212.248.0/26;
  set_real_ip_from 3.10.17.128/25;
  set_real_ip_from 3.11.53.0/24;
  set_real_ip_from 52.56.127.0/25;
  set_real_ip_from 15.188.184.0/24;
  set_real_ip_from 52.47.139.0/24;
  set_real_ip_from 18.229.220.192/26;
  set_real_ip_from 54.233.255.128/26;
  set_real_ip_from 3.231.2.0/25;
  set_real_ip_from 3.234.232.224/27;
  set_real_ip_from 3.236.169.192/26;
  set_real_ip_from 3.236.48.0/23;
  set_real_ip_from 34.195.252.0/24;
  set_real_ip_from 34.226.14.0/24;
  set_real_ip_from 13.59.250.0/26;
  set_real_ip_from 18.216.170.128/25;
  set_real_ip_from 3.128.93.0/24;
  set_real_ip_from 3.134.215.0/24;
  set_real_ip_from 52.15.127.128/26;
  set_real_ip_from 3.101.158.0/23;
  set_real_ip_from 34.216.51.0/25;
  set_real_ip_from 34.223.12.224/27;
  set_real_ip_from 34.223.80.192/26;
  set_real_ip_from 35.162.63.192/26;
  set_real_ip_from 35.167.191.128/26;
  set_real_ip_from 44.227.178.0/24;
  set_real_ip_from 44.234.108.128/25;
  set_real_ip_from 44.234.90.252/30;


  # Pull the real client's IP address out of X-Forwarded-For
  set_real_ip_from 172.16.0.0/16;
  real_ip_header X-Forwarded-For;

  # Create new variable $lb_if_proxied.
  #
  # With the realip module enabled, $remote_addr will be the end-user's IP
  # address, potentially from X-Forwarded-For, and $realip_remote_addr will be
  # the actual immediate client IP address.
  #
  # Return the load balancer IP address ($realip_remote_addr) if the request
  # looks like it was proxied. If the request does not look like it was proxied
  # (when $remote_addr is a private IP address), then return "-" instead.
  map $remote_addr $lb_if_proxied {
    "~^127\." "-";
    "~^10\." "-";
    "~^172\.1[6-9]\." "-";
    "~^172\.2[0-9]\." "-";
    "~^172\.3[0-1]\." "-";
    "~^192\.168\." "-";
    default $realip_remote_addr;
  }

  # Specify a key=value format useful for machine parsing
  log_format kv escape=json
    '{'
        '"time": "$time_local", '
        '"hostname": "$host", '
        '"dest_port": "$server_port", '
        '"dest_ip": "$server_addr", '
        '"src": "$remote_addr", '
        '"src_ip": "$realip_remote_addr", '
        '"user": "$remote_user", '
        '"protocol": "$server_protocol", '
        '"http_method": "$request_method", '
        '"status": "$status", '
        '"bytes_out": "$body_bytes_sent", '
        '"bytes_in": "$request_length", '
        '"http_referer": "$http_referer", '
        '"http_user_agent": "$http_user_agent", '
        '"nginx_version": "$nginx_version", '
        '"lb_if_proxied": "$lb_if_proxied", '
        '"http_x_forwarded_for": "$http_x_forwarded_for", '
        '"http_x_amzn_trace_id": "$http_x_amzn_trace_id", '
        '"response_time": "$upstream_response_time", '
        '"request_time": "$request_time", '
        '"request": "$request", '
        '"uri_path": "$uri", '
        '"uri_query": "$query_string"'
    '}';

  access_log /var/log/nginx/access.log kv;
  error_log  /var/log/nginx/error.log info;

  # Get $status_reason variable, a human readable version of $status
  include status-map.conf;

  include sites.d/*.conf;
}
```

</details>