### PR TITLE
Add all private IPv4 space to CIDRs to be ingnored in source IP calculation

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -18,12 +18,6 @@ default[:passenger][:production][:version] = '6.0.14'
 # Use stable (even-numbered) version of NGINX
 default[:passenger][:production][:nginx][:version] = '1.22.0'
 
-# Allow our local /16 to proxy setting X-Forwarded-For
-# This is a little broad, but because we expect security group rules to prevent
-# anyone except our trusted ALB from connecting anyway, we don't really care
-# who is able to set X-Forwarded-For headers.
-#default[:passenger][:production][:realip_from_cidr] = node.fetch(:cloud).fetch('local_ipv4').split('.')[0..1].join('.') + '.0.0/16'
-default[:passenger][:production][:realip_from_cidr] = '172.16.0.0/16'
 # Adds Cloudfront CIDRS to the set_real_ip_from to allow for proper client ip preservation
 default[:passenger][:production][:enable_cloudfront_support] = true
 

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -139,7 +139,7 @@ template "#{nginx_path}/conf/nginx.conf" do
     cloudfront_cidrs_v6: lazy {
       # Grab Cloudfront IPv6 CIDR list from the CLOUDFRONT subset of Amazon IPv6 ranges
       # (There is no seperate CLOUDFRONT_ORIGIN_FACING set for IPv6)
-      shell_out("curl -s #{aws_ip_ranges_url} | jq -r '.ipv6_prefixes[] | select(.service=="\CLOUDFRONT\") | .ipv6_prefix'").stdout.split("\n")
+      shell_out("curl -s #{aws_ip_ranges_url} | jq -r '.ipv6_prefixes[] | select(.service==\"CLOUDFRONT\") | .ipv6_prefix'").stdout.split("\n")
     }
   )
 end

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -133,13 +133,12 @@ template "#{nginx_path}/conf/nginx.conf" do
     cloudfront_cidrs_v4: lazy {
       # Grab Cloudfront IPv4 CIDR list from the CLOUDFRONT_ORIGIN_FACING subset
       # of Amazon IPv4 ranges
-      shell_out("curl -s #{aws_ip_ranges_url} | jq -r '.prefixes[] | select(.service==\\"CLOUDFRONT_ORIGIN_FACING\\") | .ip_prefix'").stdout.split("\n")
-    }
-
+      shell_out("curl -s #{aws_ip_ranges_url} | jq -r '.prefixes[] | select(.service==\"CLOUDFRONT_ORIGIN_FACING\") | .ip_prefix'").stdout.split("\n")
+    },
     cloudfront_cidrs_v6: lazy {
       # Grab Cloudfront IPv6 CIDR list from the CLOUDFRONT subset of Amazon IPv6 ranges
       # (There is no seperate CLOUDFRONT_ORIGIN_FACING set for IPv6)
-      shell_out("curl -s #{aws_ip_ranges_url} | jq -r '.ipv6_prefixes[] | select(.service==\\"CLOUDFRONT\\") | .ipv6_prefix'").stdout.split("\n")
+      shell_out("curl -s #{aws_ip_ranges_url} | jq -r '.ipv6_prefixes[] | select(.service==\"CLOUDFRONT\") | .ipv6_prefix'").stdout.split("\n")
     }
   )
 end

--- a/passenger/recipes/daemon.rb
+++ b/passenger/recipes/daemon.rb
@@ -133,13 +133,13 @@ template "#{nginx_path}/conf/nginx.conf" do
     cloudfront_cidrs_v4: lazy {
       # Grab Cloudfront IPv4 CIDR list from the CLOUDFRONT_ORIGIN_FACING subset
       # of Amazon IPv4 ranges
-      shell_out("curl -s #{aws_ip_ranges_url} | jq -r '.prefixes[] | select(.service==\"CLOUDFRONT_ORIGIN_FACING\") | .ip_prefix'").stdout.split("\n")
+      shell_out("curl -s #{aws_ip_ranges_url} | jq -r '.prefixes[] | select(.service==\\"CLOUDFRONT_ORIGIN_FACING\\") | .ip_prefix'").stdout.split("\n")
     }
 
     cloudfront_cidrs_v6: lazy {
       # Grab Cloudfront IPv6 CIDR list from the CLOUDFRONT subset of Amazon IPv6 ranges
       # (There is no seperate CLOUDFRONT_ORIGIN_FACING set for IPv6)
-      shell_out("curl -s #{aws_ip_ranges_url} | jq -r '.ipv6_prefixes[] | select(.service==\"CLOUDFRONT\") | .ipv6_prefix'").stdout.split("\n")
+      shell_out("curl -s #{aws_ip_ranges_url} | jq -r '.ipv6_prefixes[] | select(.service==\\"CLOUDFRONT\\") | .ipv6_prefix'").stdout.split("\n")
     }
   )
 end

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -59,38 +59,28 @@ http {
   # Enable XSS filter
   add_header X-XSS-Protection "1; mode=block";
 
-<% if @passenger.fetch(:enable_cloudfront_support) %>
   # Enables nginx to check multiple set_real_ip_from lines 
   real_ip_recursive on;
-  # Add Cloudfront CIDRS to trusted CIDR range for real ip computation
-  <% @cloudfront_cidrs.each do |cidr| %>
+
+  real_ip_header X-Forwarded-For;
+
+  # Exclude all private IPv4 space from client source calculation when
+  # processing the X-Forewarded-For header
+  set_real_ip_from 10.0.0.0/8;
+  set_real_ip_from 100.64.0.0/10;
+  set_real_ip_from 172.16.0.0/12;
+  set_real_ip_from 192.168.0.0/16;
+  # TODO - IPv6 CIDR for VPCs will require autoconfiguration
+
+<% if @passenger.fetch(:enable_cloudfront_support) %>
+  # Add CloudFront source address ranges to trusted CIDR range for real ip computation
+  <% @cloudfront_cidrs_v4.each do |cidr| %>
+  set_real_ip_from <%= cidr %>;
+  <% end %>
+  <% @cloudfront_cidrs_v6.each do |cidr| %>
   set_real_ip_from <%= cidr %>;
   <% end %>
 <% end -%>
-   
-
-  # Pull the real client's IP address out of X-Forwarded-For
-  set_real_ip_from <%= @passenger.fetch(:realip_from_cidr) %>;
-  real_ip_header X-Forwarded-For;
-
-  # Create new variable $lb_if_proxied.
-  #
-  # With the realip module enabled, $remote_addr will be the end-user's IP
-  # address, potentially from X-Forwarded-For, and $realip_remote_addr will be
-  # the actual immediate client IP address.
-  #
-  # Return the load balancer IP address ($realip_remote_addr) if the request
-  # looks like it was proxied. If the request does not look like it was proxied
-  # (when $remote_addr is a private IP address), then return "-" instead.
-  map $remote_addr $lb_if_proxied {
-    "~^127\." "-";
-    "~^10\." "-";
-    "~^172\.1[6-9]\." "-";
-    "~^172\.2[0-9]\." "-";
-    "~^172\.3[0-1]\." "-";
-    "~^192\.168\." "-";
-    default $realip_remote_addr;
-  }
 
   # Specify a key=value format useful for machine parsing
   log_format kv escape=json
@@ -111,7 +101,6 @@ http {
         '"http_user_agent": "$http_user_agent", '
         '"nginx_version": "$nginx_version", '
 <% if @passenger.fetch(:log_alb_headers) %>
-        '"lb_if_proxied": "$lb_if_proxied", '
         '"http_x_forwarded_for": "$http_x_forwarded_for", '
         '"http_x_amzn_trace_id": "$http_x_amzn_trace_id", '
 <% end %>


### PR DESCRIPTION
* Drops the already busted local VPC calculation and just uses the
  three RFC1918 blocks plus the carrier NAT space to the list of
  ranges not to consider in figuring out the source IP from X-Forwarded-For
* Adds support for CloudFront's IPv6 ranges for when we turn on v6