### PR TITLE
Add custom CloudWatch headers to NGINX access logs

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -5,8 +5,15 @@ default[:passenger][:production][:native_support_dir] = node.fetch(:passenger).f
 
 default[:passenger][:production][:configure_flags] = "--with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-ld-opt=\"-L/usr/lib/x86_64-linux-gnu/lib\" --with-cc-opt=\"-I/usr/include/x86_64-linux-gnu/openssl\""
 default[:passenger][:production][:log_path] = '/var/log/nginx'
+
 # Relevant for any NGINX instance behind an ALB
 default[:passenger][:production][:log_alb_headers] = true
+
+# Relevant for any NGINX instance behind CloudFront with the related
+# extended headers enabled in the Origin Request Policy
+# See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-cloudfront-headers.html#cloudfront-headers-viewer-location
+default[:passenger][:production][:log_cloudfront_headers] = true
+
 # Relevant only when client certificates are passed directly to NGINX
 default[:passenger][:production][:log_client_ssl] = false
 

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -100,6 +100,13 @@ http {
         '"http_referer": "$http_referer", '
         '"http_user_agent": "$http_user_agent", '
         '"nginx_version": "$nginx_version", '
+<% if @passenger.fetch(:log_cloudfront_headers) %>
+        '"http_cloudfront_viewer_address": "$http_cloudfront_viewer_address", '
+        '"http_cloudfront_viewer_http_version": "$http_cloudfront_viewer_http_version", '
+        '"http_cloudfront_viewer_tls": "$http_cloudfront_viewer_tls", '
+        '"http_cloudfront_viewer_country": "$http_cloudfront_viewer_country", '
+        '"http_cloudfront_viewer_country_region": "$http_cloudfront_viewer_country_region", '
+<% end %>
 <% if @passenger.fetch(:log_alb_headers) %>
         '"http_x_forwarded_for": "$http_x_forwarded_for", '
         '"http_x_amzn_trace_id": "$http_x_amzn_trace_id", '


### PR DESCRIPTION
Logs the following headers to `/var/log/nginx/access.log` being populated by CloudFront as of Requires https://github.com/18F/identity-devops/pull/5075

* `CloudFront-Viewer-Address`  -> `http_cloudfront_viewer_address` : Source IP and port for client connection to CloudFront
* `CloudFront-Viewer-Http-Version` -> `http_cloudfront_viewer_http_version` : HTTP version used for client connection to CloudFront
* `CloudFront-Viewer-TLS` ->  `http_cloudfront_viewer_tls` : TLS version and ciphers used for client connection to CloudFront
* `CloudFront-Viewer-Country` -> `http_cloudfront_viewer_country` : ISO country code for IP client used to connect
* `CloudFront-Viewer-Country-Region` -> `http_cloudfront_viewer_country_region` : ISO region subcode for IP client used to connect

Sample log output:
~~~json
{
  "time": "09/Aug/2022:04:44:03 +0000",
  "hostname": "idp.sshelton.identitysandbox.gov",
  "dest_port": "443",
  "dest_ip": "100.106.104.147",
  "src": "98.240.210.150",
  "src_ip": "100.106.81.45",
  "user": "",
  "protocol": "HTTP/1.1",
  "http_method": "GET",
  "status": "200",
  "bytes_out": "31790",
  "bytes_in": "1516",
  "http_referer": "",
  "http_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36",
  "nginx_version": "1.22.0",
  "http_x_forwarded_for": "98.240.210.150, 70.132.37.135:33862",
  "http_x_amzn_trace_id": "Root=1-62f1e613-7490e5a65e4c065448c5798f",
  "http_cloudfront_viewer_address": "98.240.210.150:52203",   <-- Real source IP and port
  "http_cloudfront_viewer_http_version": "2.0",   <-- HTTP/2
  "http_cloudfront_viewer_tls": "TLSv1.3:TLS_AES_128_GCM_SHA256:sessionResumed",   <-- TLS 1.3... boss!
  "http_cloudfront_viewer_country": "US",
  "http_cloudfront_viewer_country_region": "MN",   <-- OPE!
  "response_time": "0.052",
  "request_time": "0.051",
  "request": "GET / HTTP/1.1",
  "uri_path": "/",
  "uri_query": ""
}
~~~