### PR TITLE
Add headers_more module to nginx and remove server/x-powered-by

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -1,9 +1,24 @@
 cache_dir = node.fetch(:identity_shared_attributes).fetch(:cache_dir)
 
+default[:passenger][:production][:version] = '6.0.14'
+# Use stable (even-numbered) version of NGINX
+default[:passenger][:production][:nginx][:version] = '1.22.0'
+default[:passenger][:production][:headers_more][:version] = '0.34'
+
 default[:passenger][:production][:path] = '/opt/nginx'
 default[:passenger][:production][:native_support_dir] = node.fetch(:passenger).fetch(:production).fetch(:path) + '/passenger-native-support'
+default[:passenger][:production][:headers_more_path] = node[:passenger][:production][:path] +
+  '/src/headers-more-nginx-module-' +
+  node[:passenger][:production][:headers_more][:version]
 
-default[:passenger][:production][:configure_flags] = "--with-ipv6 --with-http_stub_status_module --with-http_ssl_module --with-http_realip_module --with-ld-opt=\"-L/usr/lib/x86_64-linux-gnu/lib\" --with-cc-opt=\"-I/usr/include/x86_64-linux-gnu/openssl\""
+default[:passenger][:production][:configure_flags] = "--with-ipv6 \
+  --with-http_stub_status_module \
+  --with-http_ssl_module \
+  --with-http_realip_module \
+  --with-ld-opt=\"-L/usr/lib/x86_64-linux-gnu/lib\" \
+  --with-cc-opt=\"-I/usr/include/x86_64-linux-gnu/openssl\" \
+  --add-module=#{node[:passenger][:production][:headers_more_path]}"
+
 default[:passenger][:production][:log_path] = '/var/log/nginx'
 
 # Relevant for any NGINX instance behind an ALB
@@ -21,10 +36,6 @@ default[:passenger][:production][:log_client_ssl] = false
 default[:passenger][:production][:status_server] = true
 
 default[:passenger][:production][:user] = node.fetch(:identity_shared_attributes).fetch(:production_user)
-default[:passenger][:production][:version] = '6.0.14'
-# Use stable (even-numbered) version of NGINX
-default[:passenger][:production][:nginx][:version] = '1.22.0'
-
 # Adds Cloudfront CIDRS to the set_real_ip_from to allow for proper client ip preservation
 default[:passenger][:production][:enable_cloudfront_support] = true
 

--- a/passenger/metadata.json
+++ b/passenger/metadata.json
@@ -21,5 +21,5 @@
     "passenger::daemon": "Install passenger/nginx as a service.",
     "passenger::standalone": "Install passenger/nginx and start it as standalone."
   },
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -50,8 +50,10 @@ http {
   limit_conn_status     429;
   limit_conn_zone       $binary_remote_addr zone=addr:5m;
 <% end -%>
-  # Disable sending server versions
+  # Disable sending server info and versions
   server_tokens off;
+  more_clear_headers Server;
+  more_clear_headers X-Powered-By;
   # Prevent clickJacking attack
   add_header X-Frame-Options SAMEORIGIN;
   # Disable content-type sniffing


### PR DESCRIPTION
This adds the headers_more module so we can override the forced headers added by passenger (and nginx?). It's easy to set a variable for the `Server` header if we ever want to do something fun with that.

Build completes and generates AMI
```
    amazon-ebs.ubuntu-pro:   * remote_file[/opt/nginx/src/headers-more-nginx-module-0.34.tar.gz] action create	
    amazon-ebs.ubuntu-pro:     - create new file /opt/nginx/src/headers-more-nginx-module-0.34.tar.gz	
    amazon-ebs.ubuntu-pro:     - update content in file /opt/nginx/src/headers-more-nginx-module-0.34.tar.gz from none to 0c0d2c	
    amazon-ebs.ubuntu-pro:     (new content is binary, diff output suppressed)	
    amazon-ebs.ubuntu-pro:   * execute[tar xzvf /opt/nginx/src/headers-more-nginx-module-0.34.tar.gz -C /opt/nginx/src] action run	
    amazon-ebs.ubuntu-pro:     - execute tar xzvf /opt/nginx/src/headers-more-nginx-module-0.34.tar.gz -C /opt/nginx/src	
    amazon-ebs.ubuntu-pro:   * bash[install passenger/nginx] action run	
    amazon-ebs.ubuntu-pro:     - execute "bash"	
    amazon-ebs.ubuntu-pro:   * execute[compile passenger agent] action run	
    amazon-ebs.ubuntu-pro:     - execute rbenv exec passenger-config compile-agent	
...
Build 'amazon-ebs.ubuntu-pro' finished after 45 minutes 20 seconds.	
	
==> Wait completed after 45 minutes 20 seconds	
	
==> Builds finished. The artifacts of successful builds are:	
--> amazon-ebs.ubuntu-pro: AMIs were created:	
us-west-2: ami-0b3519f2d6b0cbd0b	
	
--> amazon-ebs.ubuntu-pro: AMIs were created:	
us-west-2: ami-0b3519f2d6b0cbd0b	
	
	
[Container] 2022/09/07 06:50:55 Phase complete: BUILD State: SUCCEEDED	
```

AMI tested with IdP instance in my env and confirms that both headers are removed.
```
curl --head https://idp.jjg.identitysandbox.gov/              
HTTP/2 200 
content-type: text/html; charset=utf-8
content-length: 0
date: Wed, 07 Sep 2022 20:18:27 GMT
status: 200 OK
cache-control: no-store
vary: Accept
strict-transport-security: max-age=31556952; includeSubDomains; preload
referrer-policy: strict-origin-when-cross-origin
x-permitted-cross-domain-policies: none
pragma: no-cache
x-xss-protection: 1; mode=block
x-request-id: d4f74725-bb26-4ce7-9590-e60b0ff81061
link: <https://idp.jjg.identitysandbox.gov/assets/public-sans/PublicSans-Bold-9191c15dec4a2ea55d3e870cf678e011a5ce88ffa2840a4641bbe0ea53669468.woff2>; rel=preload; as=font; type=font/woff2; crossorigin=anonymous,<https://idp.jjg.identitysandbox.gov/assets/public-sans/PublicSans-Regular-ef3013af0f5807190388435430e1942d249f8e2c462c6db67406532d17c64aa6.woff2>; rel=preload; as=font; type=font/woff2; crossorigin=anonymous,<https://idp.jjg.identitysandbox.gov/assets/application-81c3628a11b9d64dcc542a75bf0eac91e6013ec5c4e47f853ce3dfd725d63c8c.css>; rel=preload; as=style; nopush,<https://idp.jjg.identitysandbox.gov/packs/js/form-validation-4f643982.en.js>; rel=preload; as=script; nopush,<https://idp.jjg.identitysandbox.gov/packs/js/36-ede34f04.js>; rel=preload; as=script; nopush,<https://idp.jjg.identitysandbox.gov/packs/js/application-f723e415.js>; rel=preload; as=script; nopush,<https://idp.jjg.identitysandbox.gov/packs/js/form-validation-4f643982.js>; rel=preload; as=script; nopush,<https://idp.jjg.identitysandbox.gov/packs/js/password_toggle_component-b5a1a37a.js>; rel=preload; as=script; nopush,<https://idp.jjg.identitysandbox.gov/packs/js/validated_field_component-1db347b1.js>; rel=preload; as=script; nopush,<https://idp.jjg.identitysandbox.gov/packs/js/session-expire-session-0704b440.js>; rel=preload; as=script; nopush
x-download-options: noopen
x-request-url: https://idp.jjg.identitysandbox.gov/
x-frame-options: DENY
etag: W/"991f129e8b0fb07a15b5ae43ac9f0116"
x-content-type-options: nosniff
content-security-policy: default-src 'self'; child-src 'self'; form-action 'self'; block-all-mixed-content; connect-src 'self' *.nr-data.net *.google-analytics.com us.acas.acuant.net; font-src 'self' data:; img-src 'self' data: login.gov idscangoweb.acuant.com https://s3.us-west-2.amazonaws.com; media-src 'self'; object-src 'none'; script-src 'self' js-agent.newrelic.com *.nr-data.net dap.digitalgov.gov *.google-analytics.com 'nonce-49d4cc61ba5beb5a126dd4dbf83e2704'; style-src 'self'; base-uri 'self'
x-runtime: 0.014181
set-cookie: ahoy_visitor=df55442c-58f5-4c40-850c-6877e7fcdda4; path=/; expires=Sat, 07 Sep 2024 20:18:27 GMT; SameSite=Lax; Secure; HttpOnly
set-cookie: ahoy_visit=1bb429b8-bbd9-4897-b922-75a3a1f4533e; path=/; expires=Wed, 07 Sep 2022 20:33:27 GMT; SameSite=Lax; Secure; HttpOnly
set-cookie: ahoy_track=true; path=/; SameSite=Lax; Secure; HttpOnly
set-cookie: _identity_idp_session=49d4cc61ba5beb5a126dd4dbf83e2704; path=/; secure; HttpOnly; SameSite=Lax
x-cache: Miss from cloudfront
via: 1.1 57bd3a2d9e0e4cbf89d9eb3d7dfb916e.cloudfront.net (CloudFront)
x-amz-cf-pop: SEA73-P2
x-amz-cf-id: zxTT-824iYx1f_4Bq0XAEFF3deEyecHdhcnfjBkZ7FEcX1QxYPG9Cg==
```

