### PR TITLE
add retries/retry_delay to all package installs

### DIFF
--- a/identity_base_config/recipes/default.rb
+++ b/identity_base_config/recipes/default.rb
@@ -4,7 +4,10 @@
 #
 # Common packages and config used by all hosts
 
-package 'python3-pip'
+package 'python3-pip' do
+  retries 12
+  retry_delay 5
+end
 
 execute 'install awscli as needed' do
   command 'pip3 install awscli'

--- a/identity_ruby/recipes/default.rb
+++ b/identity_ruby/recipes/default.rb
@@ -7,7 +7,11 @@ rbenv_root = node.fetch('identity_ruby').fetch('rbenv_root')
 ENV['RBENV_ROOT'] = rbenv_root
 
 # install rbenv version from apt
-package 'rbenv'
+package 'rbenv' do
+  retries 12
+  retry_delay 5
+end
+
 
 # specify bundler version
 bundler_version = node.fetch('identity_ruby').fetch('bundler_version')

--- a/passenger/recipes/install.rb
+++ b/passenger/recipes/install.rb
@@ -6,6 +6,8 @@ gem_package "passenger/system" do
   gem_binary (node.fetch(:identity_shared_attributes).fetch(:rbenv_root) + '/shims/gem')
   package_name 'passenger'
   version node[:passenger][:production][:version]
+  retries 12
+  retry_delay 5
   notifies :run, 'execute[rbenv rehash]', :immediately
 end
 

--- a/static_eip/resources/assign.rb
+++ b/static_eip/resources/assign.rb
@@ -9,11 +9,18 @@ property :sentinel_file, String
 
 action :create do
 
-  package 'awscli'
-  package 'python'
-  package 'python-netaddr'
+  ['awscli','python','python-netaddr'].each do |pkg|
+    package pkg do
+      retries 12
+      retry_delay 5
+    end
+  end
+
   execute 'apt-get -q -y remove python-pip-whl'
-  package 'python3-pip'
+  package 'python3-pip' do
+    retries 12
+    retry_delay 5
+  end
   execute 'pip3 install aws-ec2-assign-elastic-ip'
 
   # configuration comes from a data bag with specified name and item_name


### PR DESCRIPTION
Our image builds have been occasionally failing when `apt` is unable to reach one or more package repositories, particularly Ubuntu ESM, e.g.:

```
    amazon-ebs.ubuntu-pro: Err:13 https://esm.ubuntu.com/apps/ubuntu bionic-apps-security/main amd64 python3-pip all 9.0.1-2.3~ubuntu1.18.04.5+esm2
    amazon-ebs.ubuntu-pro:   Could not wait for server fd - select (11: Resource temporarily unavailable) [IP: <REDACTED> 443]
```

This PR updates all `*package` Chef resources so that each install is given up to 12 retries (with a 5-second delay between retries) before the operation is allowed to fail.