### PR TITLE
Make passenger request queue size configurable

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -51,6 +51,7 @@ default[:passenger][:production][:limit_connections] = true
 # Keep max_pool_size and min_instances the same to create a fixed process pool
 default[:passenger][:production][:max_pool_size] = node.fetch('cpu').fetch('total') * 2
 default[:passenger][:production][:min_instances] = node.fetch('cpu').fetch('total') * 2
+default[:passenger][:production][:max_request_queue_size] = 512
 
 default[:passenger][:production][:max_instances_per_app] = 0
 default[:passenger][:production][:pool_idle_time] = 0

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -15,6 +15,7 @@ http {
   passenger_max_instances_per_app       <%= @passenger[:max_instances_per_app] %>;
   passenger_max_pool_size               <%= @passenger[:max_pool_size] %>;
   passenger_min_instances               <%= @passenger[:min_instances] %>;
+  passenger_max_request_queue_size      <%= @passenger[:max_request_queue_size] %>;
   passenger_pool_idle_time              <%= @passenger[:pool_idle_time] %>;
   passenger_core_file_descriptor_ulimit <%= @passenger[:nofile_limit] %>;
 


### PR DESCRIPTION
The title says it all. This is important since the default of 100 seems more reasonable for CPU-bound apps, which we are not, ATM at least.