### PR TITLE
Log TLS protocol and version in NGINX logs

### DIFF
--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -122,6 +122,8 @@ http {
         '"ssl_client_serial": "$ssl_client_serial", '
         '"ssl_client_expire_days": "$ssl_client_v_remain", '
 <% end %>
+        '"tls_protocol": "$ssl_protocol", '
+        '"tls_cipher": "$ssl_cipher", '
         '"uri_path": "$uri", '
         '"uri_query": "$query_string"'
     '}';


### PR DESCRIPTION
Adds a little more info to help remove unused or weak ciphers.

Sample log line after change on `idp`:

~~~json
{
  "time": "20/Jan/2023:06:24:05 +0000",
  "hostname": "x.x.x.x",
  "dest_port": "443",
  "dest_ip": "y.y.y.y",
  "src": "z.z.z.z",
  "src_ip": "z.z.z.z",
  "user": "",
  "protocol": "HTTP/1.1",
  "http_method": "GET",
  "status": "200",
  "bytes_out": "129",
  "bytes_in": "139",
  "http_referer": "",
  "http_user_agent": "ELB-HealthChecker/2.0",
  "nginx_version": "1.22.0",
  "http_cloudfront_viewer_address": "",
  "http_cloudfront_viewer_http_version": "",
  "http_cloudfront_viewer_tls": "",
  "http_cloudfront_viewer_country": "",
  "http_cloudfront_viewer_country_region": "",
  "http_x_forwarded_for": "",
  "http_x_amzn_trace_id": "",
  "response_time": "0.105",
  "request_time": "0.106",
  "request": "GET /api/health HTTP/1.1",
  "tls_protocol": "TLSv1.2",   <-- Protocol!
  "tls_cipher": "ECDHE-RSA-AES256-GCM-SHA384",  <-- Ciphers!
  "uri_path": "/api/health",
  "uri_query": ""
}
~~~