### PR TITLE
Adding line to disable CBC mode ciphers

### DIFF
--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -128,6 +128,8 @@ http {
         '"uri_query": "$query_string"'
     '}';
 
+  ssl_ciphers !SHA1:!SHA256:!SHA384
+
   access_log <%= @log_path or raise "no @log_path" %>/access.log kv;
   error_log  <%= @log_path or raise "no @log_path" %>/error.log info;
 


### PR DESCRIPTION
Adding !SHA1:!SHA256:!SHA384 to disable all CBC mode ciphers. 

While GCM and CHACHA20 ciphers have SHA* in their name, they're not disabled because they use their own MAC algorithm. The SHA* in their name is for [the PRF](https://crypto.stackexchange.com/questions/26410/whats-the-gcm-sha-256-of-a-tls-protocol/26434#26434), [not the MAC](https://crypto.stackexchange.com/questions/26410/whats-the-gcm-sha-256-of-a-tls-protocol/26434#26434)

![Screen Shot 2023-02-14 at 2 53 40 PM](https://user-images.githubusercontent.com/116311760/218852606-b118c1a6-b674-458d-96df-81052a98a6a4.png)
