### PR TITLE
Update passenger and nginx to latest stable releases

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -1,8 +1,8 @@
 cache_dir = node.fetch(:identity_shared_attributes).fetch(:cache_dir)
 
-default[:passenger][:production][:version] = '6.0.14'
+default[:passenger][:production][:version] = '6.0.17'
 # Use stable (even-numbered) version of NGINX
-default[:passenger][:production][:nginx][:version] = '1.22.0'
+default[:passenger][:production][:nginx][:version] = '1.22.1'
 default[:passenger][:production][:headers_more][:version] = '0.34'
 
 default[:passenger][:production][:path] = '/opt/nginx'


### PR DESCRIPTION
https://github.com/phusion/passenger/releases/tag/release-6.0.17

> Upgrades preferred Nginx to 1.22.1 from 1.20.2.

Upgrades passenger to the latest stable version and ditto for nginx.