### PR TITLE
Add optional app flag to ConfigLoader to use an alternate secret bucket

### DIFF
--- a/config_loader/libraries/config_helper.rb
+++ b/config_loader/libraries/config_helper.rb
@@ -1,8 +1,8 @@
 require 'json'
 
 class Chef::Recipe::ConfigLoader
-  def self.load_config(node, key, common: false)
-    url = "s3://#{node['login_dot_gov']['secrets_bucket']}"
+  def self.load_config(node, key, app: false, common: false)
+    url = app ? "s3://#{node['login_dot_gov']['app_secrets_bucket']}" : "s3://#{node['login_dot_gov']['secrets_bucket']}"
     prefix = common ? "common" : node.chef_environment
     url = "#{url}/#{prefix}/#{key}"
     result = `aws s3 cp #{url} - 2>&1`
@@ -17,8 +17,8 @@ class Chef::Recipe::ConfigLoader
   # 404 response code. This only applies to cases where node.chef_environment
   # is not "prod". In the "prod" environment, always raise on errors and never
   # return nil.
-  def self.load_config_or_nil(node, key, print_warnings: true)
-    raw = load_config(node, key)
+  def self.load_config_or_nil(node, key, app: false, common: false, print_warnings: true)
+    raw = load_config(node, key, app: app, common: common)
   rescue StandardError => err
     if (err.message =~ /An error occurred \(404\)/ &&
         node.chef_environment != "prod")
@@ -31,8 +31,8 @@ class Chef::Recipe::ConfigLoader
 
   # Like load_config, but designed to handle nested secrets data. If the
   # contents are being loaded, also JSON.parse the data.
-  def self.load_json(node, key, common: false)
-    url = "s3://#{node['login_dot_gov']['secrets_bucket']}"
+  def self.load_json(node, key, app: false, common: false)
+    url = app ? "s3://#{node['login_dot_gov']['app_secrets_bucket']}" : "s3://#{node['login_dot_gov']['secrets_bucket']}"
     prefix = common ? "common" : node.chef_environment
     url = "#{url}/#{prefix}/#{key}"
     raw = `aws s3 cp #{url} - 2>&1`.chomp


### PR DESCRIPTION
* Adds the `app` flag to ConfigLoader which instructs it to load the application instead of platform level secret
* Fixes `load_config_or_nil` to pass through flags to `load_config`