### PR TITLE
Update Passenger version to 6.0.19

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -1,6 +1,6 @@
 cache_dir = node.fetch(:identity_shared_attributes).fetch(:cache_dir)
 
-default[:passenger][:production][:version] = '6.0.17'
+default[:passenger][:production][:version] = '6.0.19'
 # Use stable (even-numbered) version of NGINX
 default[:passenger][:production][:nginx][:version] = '1.22.1'
 default[:passenger][:production][:headers_more][:version] = '0.34'


### PR DESCRIPTION
This updates Passenger to version [6.0.19](https://github.com/phusion/passenger/releases/tag/release-6.0.19) which includes a patch to fix an [incompatibility](https://github.com/phusion/passenger/issues/2503) with Rack 3.

The related IDP pull request is https://github.com/18F/identity-idp/pull/9359

The Passenger upgrade is currently running with the Rack 3 upgrade in the https://idp.mhenke.identitysandbox.gov/ environment.
