### PR TITLE
ALB TLS and Cipher Headers

### DIFF
--- a/passenger/attributes/daemon.rb
+++ b/passenger/attributes/daemon.rb
@@ -23,6 +23,7 @@ default[:passenger][:production][:log_path] = '/var/log/nginx'
 
 # Relevant for any NGINX instance behind an ALB
 default[:passenger][:production][:log_alb_headers] = true
+default[:passenger][:production][:log_alb_ssl] = true
 
 # Relevant for any NGINX instance behind CloudFront with the related
 # extended headers enabled in the Origin Request Policy

--- a/passenger/templates/default/nginx.conf.erb
+++ b/passenger/templates/default/nginx.conf.erb
@@ -123,6 +123,10 @@ http {
         '"ssl_client_serial": "$ssl_client_serial", '
         '"ssl_client_expire_days": "$ssl_client_v_remain", '
 <% end %>
+<% if @passenger.fetch(:log_alb_ssl) %>
+        '"http_x_amzn_tls_version": "$http_x_amzn_tls_version", '
+        '"http_x_amzn_tls_cipher_suite": "$http_x_amzn_tls_cipher_suite", '
+<% end %>
         '"tls_protocol": "$ssl_protocol", '
         '"tls_cipher": "$ssl_cipher", '
         '"uri_path": "$uri", '


### PR DESCRIPTION
### ALB TLS and Cipher Headers

This PR adds logging of the ALB TLS and Ciphers Headers to the nginx/access.log for better visibility.

Addresses #https://gitlab.login.gov/lg-people/platform/radia/radialegacy-09.15.23/-/issues/62
